### PR TITLE
Optimizations

### DIFF
--- a/calico/src/main/scala/calico/dsl.scala
+++ b/calico/src/main/scala/calico/dsl.scala
@@ -28,7 +28,6 @@ import cats.effect.kernel.Resource
 import cats.effect.kernel.Sync
 import cats.effect.std.Dispatcher
 import cats.effect.std.Hotswap
-import cats.effect.std.Supervisor
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import com.raquo.domtypes.generic.builders.EventPropBuilder
@@ -352,7 +351,6 @@ object KeyedChildren:
     with
     def modify(children: Modified[F, K], e: E) =
       for
-        sup <- Supervisor[F]
         active <- Resource.make(Ref[F].of(mutable.Map.empty[K, (dom.Node, F[Unit])]))(
           _.get.flatMap(_.values.toList.traverse_(_._2))
         )

--- a/calico/src/main/scala/calico/dsl.scala
+++ b/calico/src/main/scala/calico/dsl.scala
@@ -380,7 +380,7 @@ object KeyedChildren:
 
                   (update(nextNodes) *>
                     acquireNewNodes *>
-                    renderNextNodes).guarantee(releaseOldNodes)
+                    renderNextNodes).guarantee(releaseOldNodes.evalOn(unsafe.MacrotaskExecutor))
                 }.flatten
               }
             }

--- a/calico/src/main/scala/calico/dsl.scala
+++ b/calico/src/main/scala/calico/dsl.scala
@@ -351,7 +351,7 @@ object KeyedChildren:
         _ <- children
           .ks
           .foreach { ks =>
-            active.access.flatMap { (currentNodes, update) =>
+            active.get.flatMap { currentNodes =>
               F.uncancelable { poll =>
                 F.delay {
                   val nextNodes = mutable.Map[K, (dom.Node, F[Unit])]()
@@ -370,7 +370,7 @@ object KeyedChildren:
 
                   val renderNextNodes = F.delay(e.replaceChildren(ks.map(nextNodes(_)._1)*))
 
-                  (update(nextNodes) *>
+                  (active.set(nextNodes) *>
                     acquireNewNodes *>
                     renderNextNodes).guarantee(releaseOldNodes.evalOn(unsafe.MacrotaskExecutor))
                 }.flatten

--- a/calico/src/main/scala/calico/dsl.scala
+++ b/calico/src/main/scala/calico/dsl.scala
@@ -358,7 +358,7 @@ object KeyedChildren:
         )
         _ <- children
           .ks
-          .evalMap { ks =>
+          .foreach { ks =>
             active.access.flatMap { (currentNodes, update) =>
               F.uncancelable { poll =>
                 F.delay {

--- a/calico/src/main/scala/calico/dsl.scala
+++ b/calico/src/main/scala/calico/dsl.scala
@@ -18,6 +18,7 @@ package calico
 package dsl
 
 import calico.syntax.*
+import calico.util.DomHotswap
 import cats.Foldable
 import cats.Hash
 import cats.Monad
@@ -27,7 +28,6 @@ import cats.effect.kernel.Ref
 import cats.effect.kernel.Resource
 import cats.effect.kernel.Sync
 import cats.effect.std.Dispatcher
-import cats.effect.std.Hotswap
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import com.raquo.domtypes.generic.builders.EventPropBuilder
@@ -196,17 +196,12 @@ object Modifier:
       using F: Async[F]): Modifier[F, E, Stream[F, Option[Resource[F, E2]]]] with
     def modify(e2s: Stream[F, Option[Resource[F, E2]]], e: E) =
       for
-        (hs, c) <- Hotswap[F, dom.Node](F.delay(dom.document.createComment("")).toResource)
-        _ <- F.delay(e.appendChild(c)).toResource
-        prev <- F.ref(c).toResource
+        sentinel <- Resource.eval(F.delay(dom.document.createComment("")))
+        hs <- DomHotswap[F, dom.Node](sentinel.pure)
+        _ <- F.delay(e.appendChild(sentinel)).toResource
         _ <- e2s
-          .evalMap { next =>
-            for
-              n <- hs.swap(next.getOrElse(c.pure))
-              p <- prev.get
-              _ <- F.delay(e.replaceChild(n, p))
-              _ <- prev.set(n)
-            yield ()
+          .foreach { next =>
+            hs.swap(next.getOrElse(sentinel.pure)) { (p, n) => F.delay(e.replaceChild(n, p)) }
           }
           .compile
           .drain
@@ -314,21 +309,20 @@ object Children:
   given [F[_], E <: dom.Element](using F: Async[F]): Modifier[F, E, Modified[F]] with
     def modify(children: Modified[F], e: E) =
       for
-        hs <- Hotswap.create[F, List[dom.Node]]
+        hs <- DomHotswap[F, List[dom.Node]](Resource.pure(Nil))
         placeholder <- Resource.eval(
           F.delay(e.appendChild(dom.document.createComment("")))
         )
         _ <- children
           .cs
-          .evalScan(List.empty[dom.Node])((prevChildren, c) => {
-            hs.swap(c.evalMap { c =>
+          .foreach { children =>
+            hs.swap(children) { (prev, next) =>
               F.delay {
-                prevChildren.foreach(e.removeChild)
-                c.foreach(e.insertBefore(_, placeholder))
-                c
+                prev.foreach(e.removeChild)
+                next.foreach(e.insertBefore(_, placeholder))
               }
-            })
-          })
+            }
+          }
           .compile
           .drain
           .background

--- a/calico/src/main/scala/calico/util/DomHotswap.scala
+++ b/calico/src/main/scala/calico/util/DomHotswap.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico
+package util
+
+import cats.effect.kernel.Async
+import cats.effect.kernel.Resource
+import cats.effect.syntax.all.*
+import cats.syntax.all.*
+
+private[calico] abstract class DomHotswap[F[_], A]:
+  def swap(next: Resource[F, A])(render: (A, A) => F[Unit]): F[Unit]
+
+private[calico] object DomHotswap:
+  def apply[F[_], A](init: Resource[F, A])(
+      using F: Async[F]
+  ): Resource[F, DomHotswap[F, A]] =
+    Resource.make(init.allocated.flatMap(F.ref(_)))(_.get.flatMap(_._2)).map { active =>
+      new:
+        def swap(next: Resource[F, A])(render: (A, A) => F[Unit]) = F.uncancelable { poll =>
+          for
+            nextAllocated <- poll(next.allocated)
+            (oldA, oldFinalizer) <- active.getAndSet(nextAllocated)
+            newA = nextAllocated._1
+            _ <- render(oldA, newA)
+            _ <- oldFinalizer.evalOn(unsafe.MacrotaskExecutor)
+          yield ()
+        }
+    }

--- a/todo-mvc/src/main/scala/todomvc/TodoMvc.scala
+++ b/todo-mvc/src/main/scala/todomvc/TodoMvc.scala
@@ -89,7 +89,7 @@ object TodoMvc extends IOWebApp:
       li(
         cls <-- (todo: Signal[IO, Option[Todo]], editing: Signal[IO, Boolean]).mapN { (t, e) =>
           val completed = Option.when(t.exists(_.completed))("completed")
-          val editing = Option.when(e)("editing").toList
+          val editing = Option.when(e)("editing")
           completed.toList ++ editing.toList
         },
         onDblClick --> (_.foreach(_ => editing.set(true))),


### PR DESCRIPTION
Some micro-optimizations, but also something interesting: scheduling cleanup tasks on the `MacrotaskExecutor` so that they don't block rendering. This makes a visible difference in the TodoMVC when going from "active" to "completed" with many active todos and few completed todos, as most of the work is cleanup (i.e. deregistering the signals).

I'd like to apply the optimization in the reverse direction as well (signal registration as a macrotask), but that is a more complex change I will do in a follow-up.