### PR TITLE
Make more APIs private

### DIFF
--- a/calico/src/main/scala/calico/html/Children.scala
+++ b/calico/src/main/scala/calico/html/Children.scala
@@ -44,9 +44,9 @@ final class Children[F[_]] private[calico]:
 
 object Children:
   final class ResourceListSignalModifier[F[_]](
-      val children: Signal[F, List[Resource[F, fs2.dom.Node[F]]]])
+      private[calico] val children: Signal[F, List[Resource[F, fs2.dom.Node[F]]]])
   final class ListResourceSignalModifier[F[_]](
-      val children: Signal[F, Resource[F, List[fs2.dom.Node[F]]]])
+      private[calico] val children: Signal[F, Resource[F, List[fs2.dom.Node[F]]]])
 
 private trait ChildrenModifiers[F[_]](using F: Async[F]):
   import Children.*
@@ -113,8 +113,8 @@ final class KeyedChildren[F[_], K] private[calico] (f: K => Resource[F, fs2.dom.
 
 object KeyedChildren:
   final class ListSignalModifier[F[_], K](
-      val build: K => Resource[F, fs2.dom.Node[F]],
-      val keys: Signal[F, List[K]]
+      private[calico] val build: K => Resource[F, fs2.dom.Node[F]],
+      private[calico] val keys: Signal[F, List[K]]
   )
 
 private trait KeyedChildrenModifiers[F[_]](using F: Async[F]):

--- a/calico/src/main/scala/calico/html/Children.scala
+++ b/calico/src/main/scala/calico/html/Children.scala
@@ -34,18 +34,18 @@ import scala.scalajs.js
 final class Children[F[_]] private[calico]:
   import Children.*
 
-  inline def <--(
+  @inline def <--(
       cs: Signal[F, List[Resource[F, fs2.dom.Node[F]]]]): ResourceListSignalModifier[F] =
     ResourceListSignalModifier(cs)
 
-  inline def <--(
+  @inline def <--(
       cs: Signal[F, Resource[F, List[fs2.dom.Node[F]]]]): ListResourceSignalModifier[F] =
     ListResourceSignalModifier(cs)
 
 object Children:
-  final class ResourceListSignalModifier[F[_]](
+  final class ResourceListSignalModifier[F[_]] private[calico] (
       private[calico] val children: Signal[F, List[Resource[F, fs2.dom.Node[F]]]])
-  final class ListResourceSignalModifier[F[_]](
+  final class ListResourceSignalModifier[F[_]] private[calico] (
       private[calico] val children: Signal[F, Resource[F, List[fs2.dom.Node[F]]]])
 
 private trait ChildrenModifiers[F[_]](using F: Async[F]):
@@ -109,10 +109,10 @@ private trait ChildrenModifiers[F[_]](using F: Async[F]):
 
 final class KeyedChildren[F[_], K] private[calico] (f: K => Resource[F, fs2.dom.Node[F]]):
   import KeyedChildren.*
-  inline def <--(ks: Signal[F, List[K]]): ListSignalModifier[F, K] = ListSignalModifier(f, ks)
+  @inline def <--(ks: Signal[F, List[K]]): ListSignalModifier[F, K] = ListSignalModifier(f, ks)
 
 object KeyedChildren:
-  final class ListSignalModifier[F[_], K](
+  final class ListSignalModifier[F[_], K] private[calico] (
       private[calico] val build: K => Resource[F, fs2.dom.Node[F]],
       private[calico] val keys: Signal[F, List[K]]
   )

--- a/calico/src/main/scala/calico/html/Children.scala
+++ b/calico/src/main/scala/calico/html/Children.scala
@@ -48,7 +48,7 @@ object Children:
   final class ListResourceSignalModifier[F[_]](
       val children: Signal[F, Resource[F, List[fs2.dom.Node[F]]]])
 
-trait ChildrenModifiers[F[_]](using F: Async[F]):
+private trait ChildrenModifiers[F[_]](using F: Async[F]):
   import Children.*
 
   inline given forListResourceSignalChildren[N <: fs2.dom.Node[F]]
@@ -117,7 +117,7 @@ object KeyedChildren:
       val keys: Signal[F, List[K]]
   )
 
-trait KeyedChildrenModifiers[F[_]](using F: Async[F]):
+private trait KeyedChildrenModifiers[F[_]](using F: Async[F]):
   import KeyedChildren.*
 
   private def traverse_[A, U](it: Iterable[A])(f: A => F[U]): F[Unit] =

--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -43,9 +43,6 @@ sealed trait Html[F[_]](using F: Async[F])
       KeyedChildrenModifiers[F],
       HtmlAttrModifiers[F]:
 
-  protected def htmlTag[E <: fs2.dom.HtmlElement[F]](tagName: String, void: Boolean) =
-    HtmlTag(tagName, void)
-
   def aria: Aria[F] = Aria[F]
 
   def cls: ClassProp[F] = ClassProp[F]

--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -28,7 +28,7 @@ object io extends Html[IO]
 object Html:
   def apply[F[_]: Async]: Html[F] = new Html[F] {}
 
-trait Html[F[_]](using F: Async[F])
+sealed trait Html[F[_]](using F: Async[F])
     extends HtmlTags[F],
       Props[F],
       GlobalEventProps[F],

--- a/calico/src/main/scala/calico/html/HtmlAttr.scala
+++ b/calico/src/main/scala/calico/html/HtmlAttr.scala
@@ -53,7 +53,7 @@ object HtmlAttr:
       val values: Signal[F, Option[V]]
   )
 
-trait HtmlAttrModifiers[F[_]](using F: Async[F]):
+private trait HtmlAttrModifiers[F[_]](using F: Async[F]):
   import HtmlAttr.*
 
   inline given forConstantHtmlAttr[E <: fs2.dom.Element[F], V]

--- a/calico/src/main/scala/calico/html/HtmlAttr.scala
+++ b/calico/src/main/scala/calico/html/HtmlAttr.scala
@@ -36,21 +36,21 @@ sealed class HtmlAttr[F[_], V] private[calico] (key: String, codec: Codec[V, Str
 
 object HtmlAttr:
   final class ConstantModifier[V](
-      val key: String,
-      val codec: Codec[V, String],
-      val value: V
+      private[calico] val key: String,
+      private[calico] val codec: Codec[V, String],
+      private[calico] val value: V
   )
 
   final class SignalModifier[F[_], V](
-      val key: String,
-      val codec: Codec[V, String],
-      val values: Signal[F, V]
+      private[calico] val key: String,
+      private[calico] val codec: Codec[V, String],
+      private[calico] val values: Signal[F, V]
   )
 
   final class OptionSignalModifier[F[_], V](
-      val key: String,
-      val codec: Codec[V, String],
-      val values: Signal[F, Option[V]]
+      private[calico] val key: String,
+      private[calico] val codec: Codec[V, String],
+      private[calico] val values: Signal[F, Option[V]]
   )
 
 private trait HtmlAttrModifiers[F[_]](using F: Async[F]):

--- a/calico/src/main/scala/calico/html/HtmlAttr.scala
+++ b/calico/src/main/scala/calico/html/HtmlAttr.scala
@@ -25,29 +25,29 @@ import org.scalajs.dom
 sealed class HtmlAttr[F[_], V] private[calico] (key: String, codec: Codec[V, String]):
   import HtmlAttr.*
 
-  inline def :=(v: V): ConstantModifier[V] =
+  @inline def :=(v: V): ConstantModifier[V] =
     ConstantModifier(key, codec, v)
 
-  inline def <--(vs: Signal[F, V]): SignalModifier[F, V] =
+  @inline def <--(vs: Signal[F, V]): SignalModifier[F, V] =
     SignalModifier(key, codec, vs)
 
-  inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[F, V] =
+  @inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[F, V] =
     OptionSignalModifier(key, codec, vs)
 
 object HtmlAttr:
-  final class ConstantModifier[V](
+  final class ConstantModifier[V] private[calico] (
       private[calico] val key: String,
       private[calico] val codec: Codec[V, String],
       private[calico] val value: V
   )
 
-  final class SignalModifier[F[_], V](
+  final class SignalModifier[F[_], V] private[calico] (
       private[calico] val key: String,
       private[calico] val codec: Codec[V, String],
       private[calico] val values: Signal[F, V]
   )
 
-  final class OptionSignalModifier[F[_], V](
+  final class OptionSignalModifier[F[_], V] private[calico] (
       private[calico] val key: String,
       private[calico] val codec: Codec[V, String],
       private[calico] val values: Signal[F, Option[V]]

--- a/calico/src/main/scala/calico/html/Modifier.scala
+++ b/calico/src/main/scala/calico/html/Modifier.scala
@@ -43,7 +43,7 @@ private object Modifier:
         tail.foreach(modify(_)).compile.drain.cedeBackground.void
     }
 
-trait Modifiers[F[_]](using F: Async[F]):
+private trait Modifiers[F[_]](using F: Async[F]):
   inline given forUnit[E]: Modifier[F, E, Unit] =
     _forUnit.asInstanceOf[Modifier[F, E, Unit]]
 

--- a/calico/src/main/scala/calico/html/Prop.scala
+++ b/calico/src/main/scala/calico/html/Prop.scala
@@ -59,7 +59,7 @@ object Prop:
       val values: Signal[F, Option[V]]
   )
 
-trait PropModifiers[F[_]](using F: Async[F]):
+private trait PropModifiers[F[_]](using F: Async[F]):
   import Prop.*
 
   private inline def setProp[N, V, J](node: N, value: V, name: String, codec: Codec[V, J]) =
@@ -98,7 +98,7 @@ final class EventProp[F[_], E] private[calico] (key: String):
 object EventProp:
   final class PipeModifier[F[_], E](val key: String, val sink: Pipe[F, E, Nothing])
 
-trait EventPropModifiers[F[_]](using F: Async[F]):
+private trait EventPropModifiers[F[_]](using F: Async[F]):
   import EventProp.*
   inline given forPipeEventProp[T <: fs2.dom.Node[F], E]: Modifier[F, T, PipeModifier[F, E]] =
     _forPipeEventProp.asInstanceOf[Modifier[F, T, PipeModifier[F, E]]]
@@ -118,7 +118,7 @@ final class ClassProp[F[_]] private[calico]
 object ClassProp:
   final class SingleConstantModifier(val cls: String)
 
-trait ClassPropModifiers[F[_]](using F: Async[F]):
+private trait ClassPropModifiers[F[_]](using F: Async[F]):
   import ClassProp.*
   inline given forConstantClassProp[N]: Modifier[F, N, SingleConstantModifier] =
     _forConstantClassProp.asInstanceOf[Modifier[F, N, SingleConstantModifier]]

--- a/calico/src/main/scala/calico/html/Prop.scala
+++ b/calico/src/main/scala/calico/html/Prop.scala
@@ -42,21 +42,21 @@ sealed class Prop[F[_], V, J] private[calico] (name: String, codec: Codec[V, J])
 
 object Prop:
   final class ConstantModifier[V, J](
-      val name: String,
-      val codec: Codec[V, J],
-      val value: V
+      private[calico] val name: String,
+      private[calico] val codec: Codec[V, J],
+      private[calico] val value: V
   )
 
   final class SignalModifier[F[_], V, J](
-      val name: String,
-      val codec: Codec[V, J],
-      val values: Signal[F, V]
+      private[calico] val name: String,
+      private[calico] val codec: Codec[V, J],
+      private[calico] val values: Signal[F, V]
   )
 
   final class OptionSignalModifier[F[_], V, J](
-      val name: String,
-      val codec: Codec[V, J],
-      val values: Signal[F, Option[V]]
+      private[calico] val name: String,
+      private[calico] val codec: Codec[V, J],
+      private[calico] val values: Signal[F, Option[V]]
   )
 
 private trait PropModifiers[F[_]](using F: Async[F]):
@@ -96,7 +96,9 @@ final class EventProp[F[_], E] private[calico] (key: String):
   inline def -->(sink: Pipe[F, E, Nothing]): PipeModifier[F, E] = PipeModifier(key, sink)
 
 object EventProp:
-  final class PipeModifier[F[_], E](val key: String, val sink: Pipe[F, E, Nothing])
+  final class PipeModifier[F[_], E](
+      private[calico] val key: String,
+      private[calico] val sink: Pipe[F, E, Nothing])
 
 private trait EventPropModifiers[F[_]](using F: Async[F]):
   import EventProp.*
@@ -116,7 +118,7 @@ final class ClassProp[F[_]] private[calico]
     SingleConstantModifier(cls)
 
 object ClassProp:
-  final class SingleConstantModifier(val cls: String)
+  final class SingleConstantModifier(private[calico] val cls: String)
 
 private trait ClassPropModifiers[F[_]](using F: Async[F]):
   import ClassProp.*

--- a/calico/src/main/scala/calico/html/Prop.scala
+++ b/calico/src/main/scala/calico/html/Prop.scala
@@ -31,29 +31,29 @@ import scala.scalajs.js
 sealed class Prop[F[_], V, J] private[calico] (name: String, codec: Codec[V, J]):
   import Prop.*
 
-  inline def :=(v: V): ConstantModifier[V, J] =
+  @inline def :=(v: V): ConstantModifier[V, J] =
     ConstantModifier(name, codec, v)
 
-  inline def <--(vs: Signal[F, V]): SignalModifier[F, V, J] =
+  @inline def <--(vs: Signal[F, V]): SignalModifier[F, V, J] =
     SignalModifier(name, codec, vs)
 
-  inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[F, V, J] =
+  @inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[F, V, J] =
     OptionSignalModifier(name, codec, vs)
 
 object Prop:
-  final class ConstantModifier[V, J](
+  final class ConstantModifier[V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val codec: Codec[V, J],
       private[calico] val value: V
   )
 
-  final class SignalModifier[F[_], V, J](
+  final class SignalModifier[F[_], V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val codec: Codec[V, J],
       private[calico] val values: Signal[F, V]
   )
 
-  final class OptionSignalModifier[F[_], V, J](
+  final class OptionSignalModifier[F[_], V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val codec: Codec[V, J],
       private[calico] val values: Signal[F, Option[V]]

--- a/project/src/main/scala/calico/html/codegen/DomDefsGenerator.scala
+++ b/project/src/main/scala/calico/html/codegen/DomDefsGenerator.scala
@@ -55,7 +55,7 @@ object DomDefsGenerator {
 
     val htmlTags = {
       val traitName = "HtmlTags"
-      val traitNameWithParams = s"$traitName[F[_]]"
+      val traitNameWithParams = s"$traitName[F[_]](using Async[F])"
 
       val fileContent = generator.generateTagsTrait(
         tagType = HtmlTagType,


### PR DESCRIPTION
This reduces our public API surface even more. I believe it will also allow us to remove `Codec` from public API.

Of course, we should reconsider making some of these APIs public if they turn out to be useful to users. But prefer private as default, and publicize deliberately and thoughtfully.