### PR TITLE
Better `Eq[Signal]`

### DIFF
--- a/frp/src/test/scala/calico/frp/SignalSuite.scala
+++ b/frp/src/test/scala/calico/frp/SignalSuite.scala
@@ -96,11 +96,4 @@ class SignalSuite extends DisciplineSuite, TestInstances:
   given Ticker = Ticker()
 
   // it is stack-safe, but expensive to test
-  MonadTests[Signal[IO, _]].stackUnsafeMonad[Int, Int, Int].all.properties.foreach {
-    case (id, prop) =>
-      // TODO investigate failures #101
-      if !Set(
-          "monad (stack-unsafe).flatMap associativity",
-          "monad (stack-unsafe).semigroupal associativity").contains(id)
-      then property(id)(prop)
-  }
+  checkAll("Signal", MonadTests[Signal[IO, _]].stackUnsafeMonad[Int, Int, Int])


### PR DESCRIPTION
Rewrites it without the `Ref`. I believe this will also fix https://github.com/armanbilge/calico/issues/101.