### PR TITLE
Fix inference for `Signal` modifiers

### DIFF
--- a/calico/src/main/scala/calico/html/Modifier.scala
+++ b/calico/src/main/scala/calico/html/Modifier.scala
@@ -80,8 +80,9 @@ private trait Modifiers[F[_]](using F: Async[F]):
       }
     }
 
-  inline given forStringSignal[E <: fs2.dom.Node[F]]: Modifier[F, E, Signal[F, String]] =
-    _forStringSignal.asInstanceOf[Modifier[F, E, Signal[F, String]]]
+  inline given forStringSignal[E <: fs2.dom.Node[F], S <: Signal[F, String]]
+      : Modifier[F, E, S] =
+    _forStringSignal.asInstanceOf[Modifier[F, E, S]]
 
   private val _forStringSignal: Modifier[F, dom.Node, Signal[F, String]] = (s, e) =>
     s.getAndUpdates.flatMap { (head, tail) =>
@@ -93,9 +94,8 @@ private trait Modifiers[F[_]](using F: Async[F]):
         .void
     }
 
-  inline given forStringOptionSignal[E <: fs2.dom.Node[F]]
-      : Modifier[F, E, Signal[F, Option[String]]] =
-    _forStringOptionSignal.asInstanceOf[Modifier[F, E, Signal[F, Option[String]]]]
+  inline given forStringOptionSignal[E <: fs2.dom.Node[F], S <: Signal[F, Option[String]]]
+      : Modifier[F, E, S] = _forStringOptionSignal.asInstanceOf[Modifier[F, E, S]]
 
   private val _forStringOptionSignal: Modifier[F, dom.Node, Signal[F, Option[String]]] =
     _forStringSignal.contramap(_.map(_.getOrElse("")))
@@ -115,9 +115,11 @@ private trait Modifiers[F[_]](using F: Async[F]):
   private val _forNode: Modifier[F, dom.Node, Resource[F, dom.Node]] = (n2, n) =>
     n2.evalMap(n2 => F.delay(n.appendChild(n2)))
 
-  inline given forNodeSignal[N <: fs2.dom.Node[F], N2 <: fs2.dom.Node[F]]
-      : Modifier[F, N, Signal[F, Resource[F, N2]]] =
-    _forNodeSignal.asInstanceOf[Modifier[F, N, Signal[F, Resource[F, N2]]]]
+  inline given forNodeSignal[
+      N <: fs2.dom.Node[F],
+      N2 <: fs2.dom.Node[F],
+      S <: Signal[F, Resource[F, N2]]
+  ]: Modifier[F, N, S] = _forNodeSignal.asInstanceOf[Modifier[F, N, S]]
 
   private val _forNodeSignal: Modifier[F, dom.Node, Signal[F, Resource[F, dom.Node]]] =
     (n2s, n) =>
@@ -132,9 +134,11 @@ private trait Modifiers[F[_]](using F: Async[F]):
         }.void
       }
 
-  inline given forNodeOptionSignal[N <: fs2.dom.Node[F], N2 <: fs2.dom.Node[F]]
-      : Modifier[F, N, Signal[F, Option[Resource[F, N2]]]] =
-    _forNodeOptionSignal.asInstanceOf[Modifier[F, N, Signal[F, Option[Resource[F, N2]]]]]
+  inline given forNodeOptionSignal[
+      N <: fs2.dom.Node[F],
+      N2 <: fs2.dom.Node[F],
+      S <: Signal[F, Option[Resource[F, N2]]]
+  ]: Modifier[F, N, S] = _forNodeOptionSignal.asInstanceOf[Modifier[F, N, S]]
 
   private val _forNodeOptionSignal
       : Modifier[F, dom.Node, Signal[F, Option[Resource[F, dom.Node]]]] = (n2s, n) =>

--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package not.calico
+
+import calico.html.io.*
+import calico.html.io.given
+import cats.effect.*
+import fs2.concurrent.*
+
+class SyntaxSuite {
+
+  def stringSignal: SignallingRef[IO, String] = ???
+  def stringOptionSignal: SignallingRef[IO, Option[String]] = ???
+  def nodeSignal: SignallingRef[IO, Resource[IO, fs2.dom.Node[IO]]] = ???
+  def nodeOptionSignal: SignallingRef[IO, Option[Resource[IO, fs2.dom.Node[IO]]]] = ???
+
+  def signalModifiers =
+    div(
+      stringSignal,
+      stringOptionSignal,
+      nodeSignal,
+      nodeOptionSignal
+    )
+
+}


### PR DESCRIPTION
Previously, `SignallingRef` had to be upcast to `Signal` for the modifier to pick up; now it should just work. Thanks to @mn98 for reporting!