### PR TITLE
Add modifier instance for tuple of modifiers

### DIFF
--- a/calico/src/main/scala/calico/html/Modifier.scala
+++ b/calico/src/main/scala/calico/html/Modifier.scala
@@ -51,6 +51,9 @@ object Modifier:
       [a] => (r: Resource[F, Unit], m: Modifier[F, E, a], a: a) => r *> m.modify(a, e)
     }
 
+  given forOption[F[_], E, A](using M: Modifier[F, E, A]): Modifier[F, E, Option[A]] =
+    (as, e) => as.foldMapM(M.modify(_, e)).void
+
   given forList[F[_], E, A](using M: Modifier[F, E, A]): Modifier[F, E, List[A]] =
     (as, e) => as.foldMapM(M.modify(_, e)).void
 

--- a/calico/src/main/scala/calico/html/Modifier.scala
+++ b/calico/src/main/scala/calico/html/Modifier.scala
@@ -51,8 +51,7 @@ object Modifier:
       [a] => (r: Resource[F, Unit], m: Modifier[F, E, a], a: a) => r *> m.modify(a, e)
     }
 
-  given forList[F[_], E <: fs2.dom.Node[F], A](
-      using M: Modifier[F, E, A]): Modifier[F, E, List[A]] =
+  given forList[F[_], E, A](using M: Modifier[F, E, A]): Modifier[F, E, List[A]] =
     (as, e) => as.foldMapM(M.modify(_, e)).void
 
   given forResource[F[_], E, A](using M: Modifier[F, E, A]): Modifier[F, E, Resource[F, A]] =

--- a/calico/src/main/scala/calico/html/Modifier.scala
+++ b/calico/src/main/scala/calico/html/Modifier.scala
@@ -51,6 +51,9 @@ object Modifier extends ModifierLowPriority:
       [a] => (r: Resource[F, Unit], m: Modifier[F, E, a], a: a) => r *> m.modify(a, e)
     }
 
+  given forResource[F[_], E, A](using M: Modifier[F, E, A]): Modifier[F, E, Resource[F, A]] =
+    (a, e) => a.flatMap(M.modify(_, e))
+
   inline given [F[_], E]: Contravariant[Modifier[F, E, _]] =
     _contravariant.asInstanceOf[Contravariant[Modifier[F, E, _]]]
   private val _contravariant: Contravariant[Modifier[Id, Any, _]] = new:
@@ -112,10 +115,6 @@ private trait Modifiers[F[_]](using F: Async[F]):
 
   private val _forStringOptionSignal: Modifier[F, dom.Node, Signal[F, Option[String]]] =
     _forStringSignal.contramap(_.map(_.getOrElse("")))
-
-  given forResource[E <: fs2.dom.Node[F], A](
-      using M: Modifier[F, E, A]): Modifier[F, E, Resource[F, A]] =
-    (a, e) => a.flatMap(M.modify(_, e))
 
   inline given forNode[N <: fs2.dom.Node[F], N2 <: fs2.dom.Node[F]]
       : Modifier[F, N, Resource[F, N2]] =

--- a/calico/src/main/scala/calico/html/Modifier.scala
+++ b/calico/src/main/scala/calico/html/Modifier.scala
@@ -37,6 +37,12 @@ trait Modifier[F[_], E, A]:
     (b: B, e: E) => outer.modify(f(b), e)
 
 object Modifier:
+  inline given forUnit[F[_], E]: Modifier[F, E, Unit] =
+    _forUnit.asInstanceOf[Modifier[F, E, Unit]]
+
+  private val _forUnit: Modifier[Id, Any, Unit] =
+    (_, _) => Resource.unit
+
   inline given [F[_], E]: Contravariant[Modifier[F, E, _]] =
     _contravariant.asInstanceOf[Contravariant[Modifier[F, E, _]]]
   private val _contravariant: Contravariant[Modifier[Id, Any, _]] = new:
@@ -62,11 +68,6 @@ object Modifier:
     }
 
 private trait Modifiers[F[_]](using F: Async[F]):
-  inline given forUnit[E]: Modifier[F, E, Unit] =
-    _forUnit.asInstanceOf[Modifier[F, E, Unit]]
-
-  private val _forUnit: Modifier[F, Any, Unit] =
-    (_, _) => Resource.unit
 
   inline given forString[E <: fs2.dom.Node[F]]: Modifier[F, E, String] =
     _forString.asInstanceOf[Modifier[F, E, String]]


### PR DESCRIPTION
This generalizes the existing machinery in `HtmlTag` so that it can replicated more easily in userland e.g. to support:

```scala
def MyComponent[M](mods: M)(using Modifier[IO, HtmlDivElement[IO], M]) = 
  div(
    cls := "custom-class",
    otherMod1,
    otherMod2,
    mods
  )
```

h/t @yurique