### PR TITLE
Add `modify` syntax

### DIFF
--- a/calico/src/main/scala/calico/syntax.scala
+++ b/calico/src/main/scala/calico/syntax.scala
@@ -17,6 +17,7 @@
 package calico
 package syntax
 
+import calico.html.Modifier
 import cats.Functor
 import cats.data.State
 import cats.effect.kernel.Async
@@ -50,3 +51,7 @@ extension [F[_]](component: Resource[F, fs2.dom.Node[F]])
 extension [F[_], A](sigRef: SignallingRef[F, A])
   def zoom[B](lens: Lens[A, B])(using Functor[F]): SignallingRef[F, B] =
     SignallingRef.lens[F, A, B](sigRef)(lens.get(_), a => b => lens.replace(b)(a))
+
+extension [E](e: E)
+  inline def modify[F[_], A](a: A)(using m: Modifier[F, E, A]): Resource[F, Unit] =
+    m.modify(a, e)

--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -18,10 +18,12 @@ package not.calico
 
 import calico.html.io.*
 import calico.html.io.given
+import calico.syntax.*
 import cats.effect.*
+import cats.syntax.all.*
 import fs2.concurrent.*
 
-class SyntaxSuite {
+class SyntaxSuite:
 
   def stringSignal: SignallingRef[IO, String] = ???
   def stringOptionSignal: SignallingRef[IO, Option[String]] = ???
@@ -34,6 +36,4 @@ class SyntaxSuite {
       stringOptionSignal,
       nodeSignal,
       nodeOptionSignal
-    )
-
-}
+    ).flatTap(_.modify(cls := "foo"))


### PR DESCRIPTION
Closes https://github.com/armanbilge/calico/issues/204.

This allows to use the declarative DSL to modify an existing element e.g. `elem.modify(cls := "foo")`.

I tried to add this syntax on `Modifier` itself, but it seems that the compiler is unable to disambiguate. Might be fixed by https://github.com/lampepfl/dotty/pull/17050 but I'm not sure if it's the same problem.