### PR TITLE
Introduce `**>` syntax

### DIFF
--- a/calico/src/main/scala/calico/html/Prop.scala
+++ b/calico/src/main/scala/calico/html/Prop.scala
@@ -154,6 +154,9 @@ final class EventProp[F[_], A] private[calico] (key: String, pipe: Pipe[F, Any, 
   @inline def -->(sink: Pipe[F, A, Nothing]): PipeModifier[F] =
     PipeModifier(key, pipe.andThen(sink))
 
+  @inline def **>(fu: F[Unit]): PipeModifier[F] =
+    -->(_.foreach(_ => fu))
+
   @inline private def through[B](pipe: Pipe[F, A, B]): EventProp[F, B] =
     new EventProp(key, this.pipe.andThen(pipe))
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -106,7 +106,7 @@ val app: Resource[IO, HtmlDivElement[IO]] =
       div(
         label("North input: "),
         input.withSelf { self =>
-          onInput --> (_.foreach(_ => self.value.get.flatMap(northSig.set)))
+          onInput **> self.value.get.flatMap(northSig.set)
         },
       ),
       br(()),
@@ -116,13 +116,11 @@ val app: Resource[IO, HtmlDivElement[IO]] =
             option(disabled := true, selected := true, "Select input"),
             option(value := "north", "North"),
             option(value := "south", "South"),
-            onChange --> (
-              _.foreach(_ => self.value.get.map {
-                case "north" => Some(Cardinal.North)
-                case "south" => Some(Cardinal.South)
-                case _ => None
-              }.flatMap(cardinalSig.set(_)))
-            )
+            onChange **> self.value.get.map {
+              case "north" => Some(Cardinal.North)
+              case "south" => Some(Cardinal.South)
+              case _ => None
+            }.flatMap(cardinalSig.set(_))
           )
         },
         " ",
@@ -137,7 +135,7 @@ val app: Resource[IO, HtmlDivElement[IO]] =
       div(
         label("South input: "),
         input.withSelf { self =>
-          onInput --> (_.foreach(_ => self.value.get.flatMap(southSig.set)))
+          onInput **> self.value.get.flatMap(southSig.set)
         },
       ),
     )

--- a/docs/router.md
+++ b/docs/router.md
@@ -73,9 +73,7 @@ val app: Resource[IO, HtmlDivElement[IO]] =
               " ",
               button(
                 "+",
-                onClick --> {
-                  _.foreach(_ => n.get.map(i => countUri(i + 1)).flatMap(router.navigate))
-                }
+                onClick **> n.get.map(i => countUri(i + 1)).flatMap(router.navigate)
               )
             )
         }
@@ -92,7 +90,7 @@ val app: Resource[IO, HtmlDivElement[IO]] =
               li(
                 a(
                   href := "#",
-                  onClick --> (_.foreach(_ => router.navigate(helloUri(who)))),
+                  onClick **> router.navigate(helloUri(who)),
                   s"Hello, $who"
                 )
               )
@@ -100,7 +98,7 @@ val app: Resource[IO, HtmlDivElement[IO]] =
             li(
               a(
                 href := "#",
-                onClick --> (_.foreach(_ => router.navigate(countUri(0)))),
+                onClick **> router.navigate(countUri(0)),
                 "Let's count!"
               )
             )

--- a/todo-mvc/src/main/scala/todomvc/TodoMvc.scala
+++ b/todo-mvc/src/main/scala/todomvc/TodoMvc.scala
@@ -90,7 +90,7 @@ object TodoMvc extends IOWebApp:
           val editing = Option.when(e)("editing")
           completed.toList ++ editing.toList
         },
-        onDblClick --> (_.foreach(_ => editing.set(true))),
+        onDblClick **> editing.set(true),
         children <-- editing.map {
           case true =>
             List(
@@ -105,7 +105,7 @@ object TodoMvc extends IOWebApp:
                   onKeyDown --> {
                     _.filter(_.key == KeyValue.Enter).foreach(_ => endEdit)
                   },
-                  onBlur --> (_.foreach(_ => endEdit))
+                  onBlur **> endEdit
                 )
               }
             )
@@ -116,17 +116,13 @@ object TodoMvc extends IOWebApp:
                   cls := "toggle",
                   typ := "checkbox",
                   checked <-- todo.map(_.fold(false)(_.completed)),
-                  onInput --> {
-                    _.foreach { _ =>
-                      self.checked.get.flatMap { checked =>
-                        todo.update(_.map(_.copy(completed = checked)))
-                      }
-                    }
+                  onInput **> self.checked.get.flatMap { checked =>
+                    todo.update(_.map(_.copy(completed = checked)))
                   }
                 )
               },
               label(todo.map(_.map(_.text))),
-              button(cls := "destroy", onClick --> (_.foreach(_ => todo.set(None))))
+              button(cls := "destroy", onClick **> todo.set(None))
             )
         }
       )
@@ -155,7 +151,7 @@ object TodoMvc extends IOWebApp:
             li(
               a(
                 cls <-- filter.map(_ == f).map(Option.when(_)("selected").toList),
-                onClick --> (_.foreach(_ => router.navigate(Uri(fragment = f.fragment.some)))),
+                onClick **> router.navigate(Uri(fragment = f.fragment.some)),
                 f.toString
               )
             )

--- a/todo-mvc/src/main/scala/todomvc/TodoMvc.scala
+++ b/todo-mvc/src/main/scala/todomvc/TodoMvc.scala
@@ -157,17 +157,13 @@ object TodoMvc extends IOWebApp:
       ),
       ul(
         cls := "filters",
-        Filter
-          .values
-          .toList
-          .map { f =>
-            li(
-              a(
-                cls <-- filter.map(_ == f).map(Option.when(_)("selected").toList),
-                onClick **> router.navigate(Uri(fragment = f.fragment.some)),
-                href := s"/#${f.fragment}",
-                f.toString
-              )
+        Filter.values.toList.map { f =>
+          li(
+            a(
+              cls <-- filter.map(_ == f).map(Option.when(_)("selected").toList),
+              onClick **> router.navigate(Uri(fragment = f.fragment.some)),
+              href := s"/#${f.fragment}",
+              f.toString
             )
           )
         }


### PR DESCRIPTION
Closes https://github.com/armanbilge/calico/issues/202.

Now you can write `onFoo **> effect` to evaluate an effect every time an event is emitted. The syntax is inspired by Cats `*>` aka `productR` i.e. a `flatMap` that ignores the result of the left-side.

I worry that this syntax obfuscates an important detail, that is clearer when working with a stream with the `-->` syntax. Specifically, that until `effect` completes, handling of additional events will be blocked. So `effect` should not be a long-running task; instead, long-running tasks should be scheduled on some `Supervisor`.

Of course, to avoid this surprise, we could have `**>` always run `effect` on its own fiber to avoid blocking handling of additional events. I'd prefer not to do this by default, because:
1. the overhead of starting a fiber for each `effect`
2. the overhead of setting up a `Supervisor` for each `**>` 
3. it makes it easy to start an unbounded number of tasks. In general, long-running tasks should be carefully managed, and requiring the user to set up a `Supervisor` or similar makes that management explicit.

Thoughts? :)