### PR TITLE
Enable modifiers to be reified

### DIFF
--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -22,6 +22,7 @@ import calico.syntax.*
 import cats.effect.*
 import cats.syntax.all.*
 import fs2.concurrent.*
+import fs2.dom.*
 
 class SyntaxSuite:
 
@@ -30,10 +31,12 @@ class SyntaxSuite:
   def nodeSignal: SignallingRef[IO, Resource[IO, fs2.dom.Node[IO]]] = ???
   def nodeOptionSignal: SignallingRef[IO, Option[Resource[IO, fs2.dom.Node[IO]]]] = ???
 
+  def mod = (cls := "bar").toMod[Node[IO]]
+
   def signalModifiers =
     div(
       stringSignal,
       stringOptionSignal,
       nodeSignal,
       nodeOptionSignal
-    ).flatTap(_.modify(cls := "foo"))
+    ).flatTap(_.modify(cls := "foo")).flatTap(_.modify(mod))


### PR DESCRIPTION
Closes https://github.com/armanbilge/calico/issues/207.

This PR introduces `Mod[IO, Elem]` which reifies modifier, as well as a `.toMod` syntax.

This would make it possible to write:
```scala
def MyComponent(mod: Mod[IO, HtmlElement[IO]]) = 
  div(
    cls := "decoration",
    mod
  )
```

instead of
```scala
def MyComponent[M](mod: M)(using Modifier[IO, HtmlElement[IO], M]) = 
  div(
    cls := "decoration",
    mod
  )
```

and generally make it easier to pass modifiers around.

I'm not entirely sold on this yet, since it moves in the direction that `Modifier` should not be a typeclass, which in turn was motivated so that a `.toMod` extension wouldn't be needed for stuff like `String` or `HtmlElement`. But if we're going to do that anyway, then maybe we should change the encoding.

h/t @kubukoz, cc @yurique