### PR TITLE
#Enhancement:Cleaner State Management 

### DIFF
--- a/calico/src/main/scala/calico/syntax.scala
+++ b/calico/src/main/scala/calico/syntax.scala
@@ -16,9 +16,9 @@
 
 package calico
 package syntax
-
 import calico.html.Modifier
 import cats.Functor
+import cats.effect.IO
 import cats.effect.kernel.Resource
 import fs2.concurrent.SignallingRef
 import fs2.dom.Dom
@@ -35,3 +35,7 @@ extension [F[_], A](sigRef: SignallingRef[F, A])
 extension [E](e: E)
   inline def modify[F[_], A](a: A)(using m: Modifier[F, E, A]): Resource[F, Unit] =
     m.modify(a, e)
+
+extension (io: IO.type)
+  def state[A](initial: A): Resource[IO, SignallingRef[IO, A]] =
+    SignallingRef[IO].of[A](initial).toResource


### PR DESCRIPTION
### Summary
This PR introduces a state helper to simplify SignallingRef creation, reducing boilerplate and improving the ergonomics of Calico’s DSL.

### Implementation Details

Added a new extension method in  `calico/syntax.scala:`

```
extension (io: IO.type)
  def state[A](initial: A): Resource[IO, SignallingRef[IO, A]] =
    SignallingRef[IO].of[A](initial).toResource
```
Wraps the verbose `SignallingRef[IO].of(initial).toResource` pattern into a concise, reusable utility.
Integrated into the DSL to streamline state management for reactive components.

**Example Usage**
Before:

```
SignallingRef[IO].of("world").toResource.flatMap { name =>
   div(
      label("Your name: "),
      input.withSelf { self =>
        (
          placeholder := "Enter your name here",
          onInput --> (_.foreach(_ => self.value.get.flatMap(name.set)))
        )
      },
      span(" Hello, ", name.map(_.toUpperCase))
    )
}
```

After (with state):


```
IO.state("world").flatMap { name =>
    div(
      label("Your name: "),
      input.withSelf { self =>
        (
          placeholder := "Enter your name here",
          onInput --> (_.foreach(_ => self.value.get.flatMap(name.set)))
        )
      },
      span(" Hello, ", name.map(_.toUpperCase))
    )
}
```
Tested locally in a todoMvc app—builds and runs smoothly.

- **Benefits**
- Improved Readability: Cuts down repetitive code, making the DSL more concise and natural to write.
- Enhanced Ergonomics: Simplifies state setup, especially useful for Web Components in Calico.

