### PR TITLE
feat: Add type-safe input components with automatic event typing

### DIFF
--- a/calico/src/main/scala/calico/html/TypedInput.scala
+++ b/calico/src/main/scala/calico/html/TypedInput.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Calico Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.html
+
+import cats.effect.kernel.{Async, Resource}
+import fs2.dom.{HtmlInputElement, Node, File}
+import fs2.{Pipe, Stream}
+import java.time.LocalDate
+import scala.util.Try
+
+/** A type-safe input component that provides strongly typed events based on the input type */
+sealed trait TypedInput[F[_], A] {
+  def render: Resource[F, HtmlInputElement[F]]
+  def events: Pipe[F, fs2.dom.Event[F], A]
+}
+
+object TypedInput {
+  private def getValue[F[_]: Async](e: fs2.dom.Event[F]): F[String] = 
+    e.target.asInstanceOf[fs2.dom.HtmlInputElement[F]].value.get
+
+  def apply[F[_]: Async, A](inputType: String, parser: String => Option[A]): TypedInput[F, A] = 
+    new TypedInput[F, A] {
+      def render: Resource[F, HtmlInputElement[F]] = {
+        import calico.html.io.*
+        input.withSelf { self =>
+          typ := inputType
+        }
+      }
+
+      def events: Pipe[F, fs2.dom.Event[F], A] = 
+        _.evalMap(e => getValue(e).flatMap(value => 
+          Async[F].fromOption(
+            parser(value),
+            new IllegalStateException(s"Failed to parse input value '$value' as ${implicitly[scala.reflect.ClassTag[A]].runtimeClass.getSimpleName}")
+          )
+        ))
+    }
+
+  // Common input type implementations
+  def file[F[_]: Async]: TypedInput[F, File[F]] = 
+    new TypedInput[F, File[F]] {
+      def render: Resource[F, HtmlInputElement[F]] = {
+        import calico.html.io.*
+        input.withSelf { self =>
+          typ := "file"
+        }
+      }
+
+      def events: Pipe[F, fs2.dom.Event[F], File[F]] = 
+        _.evalMap(e => 
+          e.target.asInstanceOf[fs2.dom.HtmlInputElement[F]].files.get.flatMap { files =>
+            Async[F].fromOption(
+              Option(files(0)),
+              new IllegalStateException("No file selected")
+            )
+          }
+        )
+    }
+
+  def number[F[_]: Async]: TypedInput[F, Double] = 
+    apply[F, Double]("number", str => Try(str.toDouble).toOption)
+
+  def text[F[_]: Async]: TypedInput[F, String] = 
+    apply[F, String]("text", Some(_))
+
+  def date[F[_]: Async]: TypedInput[F, LocalDate] = 
+    apply[F, LocalDate]("date", str => Try(LocalDate.parse(str)).toOption)
+
+  def email[F[_]: Async]: TypedInput[F, String] = 
+    apply[F, String]("email", str => 
+      if (str.matches(".+@.+\\..+")) Some(str) else None
+    )
+
+  def password[F[_]: Async]: TypedInput[F, String] = 
+    apply[F, String]("password", Some(_))
+} 

--- a/docs/demos/typed-inputs.md
+++ b/docs/demos/typed-inputs.md
@@ -1,0 +1,89 @@
+# Typed Inputs Demo
+
+This demo shows how to use Calico's typed inputs for better type safety and validation.
+
+```scala mdoc:js
+import calico.*
+import calico.html.io.{*, given}
+import calico.html.TypedInput
+import calico.unsafe.given
+import calico.syntax.*
+import cats.effect.*
+import fs2.*
+import fs2.concurrent.*
+import fs2.dom.*
+import java.time.LocalDate
+
+case class FormData(
+  name: String,
+  email: String,
+  age: Double,
+  birthDate: LocalDate
+)
+
+val app: Resource[IO, HtmlDivElement[IO]] =
+  for {
+    nameInput <- TypedInput.text[IO].render
+    emailInput <- TypedInput.email[IO].render
+    ageInput <- TypedInput.number[IO].render
+    dateInput <- TypedInput.date[IO].render
+    formData <- SignallingRef[IO].of(Option.empty[FormData]).toResource
+
+    // Create channels for each input
+    nameCh <- Channel.unbounded[IO, String].toResource
+    emailCh <- Channel.unbounded[IO, String].toResource
+    ageCh <- Channel.unbounded[IO, Double].toResource
+    dateCh <- Channel.unbounded[IO, LocalDate].toResource
+
+    // Subscribe to input events
+    _ <- Resource.eval(
+      nameInput.events.foreach(nameCh.send) ++
+      emailInput.events.foreach(emailCh.send) ++
+      ageInput.events.foreach(ageCh.send) ++
+      dateInput.events.foreach(dateCh.send)
+    ).compile.drain.background
+
+    // Combine all inputs into FormData
+    _ <- Resource.eval(
+      (
+        nameCh.stream,
+        emailCh.stream,
+        ageCh.stream,
+        dateCh.stream
+      ).parMapN(FormData.apply).foreach(data => formData.set(Some(data)))
+    ).compile.drain.background
+
+    div <- div(
+      h1("Typed Inputs Demo"),
+      div(
+        label("Name: "), nameInput,
+        br,
+        label("Email: "), emailInput,
+        br,
+        label("Age: "), ageInput,
+        br,
+        label("Birth Date: "), dateInput
+      ),
+      div(
+        h2("Form Data:"),
+        pre(
+          formData.map(_.fold("No data yet")(data => 
+            s"""Name: ${data.name}
+               |Email: ${data.email}
+               |Age: ${data.age}
+               |Birth Date: ${data.birthDate}""".stripMargin
+          ))
+        )
+      )
+    )
+  } yield div
+
+app.renderInto(node.asInstanceOf[fs2.dom.Node[IO]]).useForever.unsafeRunAndForget()
+```
+
+The demo above shows:
+
+1. How to create typed inputs for different data types (String, Double, LocalDate)
+2. How to handle input events with proper type safety
+3. How to combine multiple typed inputs into a form
+4. How to validate inputs (email format) 


### PR DESCRIPTION
# Type-safe Input Components for Calico

This PR implements typed events for inputs as requested in #[issue_number]. It provides a type-safe way to handle input events with automatic type derivation based on input types.

## Features

- New `TypedInput[F[_], A]` trait for type-safe input components
- Automatic type derivation based on input type:
  - `TypedInput.text[F]` → `String`
  - `TypedInput.number[F]` → `Double`
  - `TypedInput.date[F]` → `LocalDate`
  - `TypedInput.email[F]` → `String` (with validation)
  - `TypedInput.password[F]` → `String`
  - `TypedInput.file[F]` → `File[F]`
- Built-in validation for specific input types (e.g., email format)
- Resource-safe input handling
- Composable with Cats Effect and FS2

## Example Usage

```scala
val app: Resource[IO, HtmlDivElement[IO]] =
  for {
    // Type-safe input components
    numberInput <- TypedInput.number[IO].render
    dateInput <- TypedInput.date[IO].render
    
    // Events are automatically typed
    _ <- Resource.eval(
      numberInput.events.foreach { value: Double =>
        // Type-safe value handling
      } ++
      dateInput.events.foreach { date: LocalDate =>
        // Type-safe date handling
      }
    ).compile.drain.background
    
    div <- div(
      label("Number: "), numberInput,
      br,
      label("Date: "), dateInput
    )
  } yield div
```

## Documentation

Added a new demo at `docs/demos/typed-inputs.md` showing:
- How to create and use typed inputs
- Type-safe event handling
- Form composition with multiple inputs
- Input validation

## Testing

- [ ] Add unit tests for TypedInput implementations
- [ ] Add integration tests for form composition
- [ ] Test browser compatibility

## Related Issues

Closes #399 