### PR TITLE
DRAFT: Redesign encoding of element DSL enhancement New feature or request

### DIFF
--- a/calico/src/main/scala/calico/html/CustomComponent3.scala
+++ b/calico/src/main/scala/calico/html/CustomComponent3.scala
@@ -1,0 +1,91 @@
+package calico
+package html
+
+import cats.effect.IO
+import fs2.{Pipe, Stream}
+import fs2.concurrent.Signal
+import org.scalajs.dom.{document, Event, HTMLElement, HTMLInputElement}
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+
+object CustomComponent {
+
+  sealed trait HtmlElementType
+  class ccinputElem extends HtmlElementType
+  class ccdivElem extends HtmlElementType
+  class cclabelElem extends HtmlElementType
+  class cculistElem extends HtmlElementType
+  class ccsectionElem extends HtmlElementType
+
+  trait Setter[E <: HtmlElementType, A, V]:
+    def set(elem: E, value: V): IO[Unit]
+
+  trait Emits[E <: HtmlElementType, Ev]:
+    def listen(elem: E, pipe: Pipe[IO, Ev, Unit]): IO[Unit]
+
+  class Tag[E <: HtmlElementType](val name: String):
+    def create: IO[E] = IO(document.createElement(name).asInstanceOf[E])
+    def apply(modifiers: (E => IO[Unit])*): IO[E] =
+      for {
+        elem <- create
+        _ <- modifiers.toList.traverse(_(elem))
+      } yield elem
+
+  class Attribute[E <: HtmlElementType, V](val key: String):
+    def :=(value: V)(using setter: Setter[E, String, V]): E => IO[Unit] =
+      (elem: E) => setter.set(elem, value)
+
+    def <--(signal: Signal[IO, V])(using setter: Setter[E, String, V]): E => IO[Unit] =
+      (elem: E) => signal.discrete.evalMap(setter.set(elem, _)).compile.drain
+
+    def -->(listener: Pipe[IO, Event, Unit])(using emits: Emits[E, Event]): E => IO[Unit] =
+      (elem: E) => emits.listen(elem, listener)
+
+  given Setter[ccinputElem, String, String] with
+    def set(elem: ccinputElem, value: String): IO[Unit] =
+      IO(elem.asInstanceOf[HTMLElement].setAttribute("id", value))
+
+  given Setter[ccdivElem, String, String] with
+    def set(elem: ccdivElem, value: String): IO[Unit] =
+      IO(elem.asInstanceOf[HTMLElement].setAttribute("class", value))
+
+  given Setter[ccinputElem, String, Boolean] with
+    def set(elem: ccinputElem, value: Boolean): IO[Unit] =
+      IO(elem.asInstanceOf[HTMLInputElement].checked = value)
+
+  given Emits[ccinputElem, Event] with
+    def listen(elem: ccinputElem, pipe: Pipe[IO, Event, Unit]): IO[Unit] =
+      IO(
+        elem
+          .asInstanceOf[HTMLElement]
+          .addEventListener(
+            "input",
+            e => pipe(Stream.emit(e).covary[IO]).compile.drain.unsafeRunAndForget()
+          )
+      )
+
+  given Emits[ccdivElem, Event] with
+    def listen(elem: ccdivElem, pipe: Pipe[IO, Event, Unit]): IO[Unit] =
+      IO(
+        elem
+          .asInstanceOf[HTMLElement]
+          .addEventListener(
+            "click",
+            e => pipe(Stream.emit(e).covary[IO]).compile.drain.unsafeRunAndForget()
+          )
+      )
+
+  val ccinputTag = Tag[ccinputElem]("input")
+  val ccdivTag = Tag[ccdivElem]("div")
+  val cculTag = Tag[cculistElem]("ul")
+  val ccsection = Tag[ccsectionElem]("section")
+  val cclabelTag = Tag[cclabelElem]("label")
+
+  val idAttr = Attribute[ccinputElem, String]("id")
+  val classAttr = Attribute[ccdivElem, String]("class")
+  val typeAttr = Attribute[ccinputElem, String]("type")
+  val checkedAttr = Attribute[ccinputElem, Boolean]("checked")
+  val onInputAttr = Attribute[ccinputElem, Event]("input")
+  val onClickAttr = Attribute[ccdivElem, Event]("click")
+
+}

--- a/calico/src/main/scala/calico/html/CustomComponent3.scala
+++ b/calico/src/main/scala/calico/html/CustomComponent3.scala
@@ -1,12 +1,32 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package calico
 package html
 
 import cats.effect.IO
-import fs2.{Pipe, Stream}
-import fs2.concurrent.Signal
-import org.scalajs.dom.{document, Event, HTMLElement, HTMLInputElement}
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
+import fs2.Pipe
+import fs2.Stream
+import fs2.concurrent.Signal
+import org.scalajs.dom.Event
+import org.scalajs.dom.HTMLElement
+import org.scalajs.dom.HTMLInputElement
+import org.scalajs.dom.document
 
 object CustomComponent {
 

--- a/sandbox/src/main/scala/calico/Sandbox.scala
+++ b/sandbox/src/main/scala/calico/Sandbox.scala
@@ -1,33 +1,86 @@
-/*
- * Copyright 2022 Arman Bilge
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package calico
-
-import calico.html.io.*
-import calico.router.*
+import calico.*
+import calico.html.CustomComponent.{*, given}
+import calico.unsafe.given
 import calico.syntax.*
 import cats.effect.*
-import cats.effect.syntax.all.*
-import cats.syntax.all.*
 import fs2.*
 import fs2.concurrent.*
 import fs2.dom.*
-import org.http4s.*
-import org.http4s.syntax.all.*
+import org.scalajs.dom.{document, Event, HTMLElement, HTMLInputElement}
+import cats.syntax.all.*
 
-object Sandbox extends IOWebApp:
+val placeholderAttr = Attribute[ccinputElem, String]("placeholder")
+val labelTextAttr = Attribute[cclabelElem, String]("textContent")
+val textContentAttr = Attribute[ccdivElem, String]("textContent")
 
-  def render = Resource.never
+given Setter[ccdivElem, String, String] with
+  def set(elem: ccdivElem, value: String): IO[Unit] =
+    IO {
+      elem.asInstanceOf[HTMLElement].textContent = value
+      elem.asInstanceOf[HTMLElement].setAttribute("class", "dynamic-content")
+    }
+
+given Setter[cclabelElem, String, String] with
+  def set(elem: cclabelElem, value: String): IO[Unit] =
+    IO(elem.asInstanceOf[HTMLElement].textContent = value)
+
+def appendChild[E1 <: HtmlElementType, E2 <: HtmlElementType](parent: E1, child: E2): IO[Unit] =
+  IO {
+    parent.asInstanceOf[HTMLElement].appendChild(child.asInstanceOf[HTMLElement])
+    ()
+  }
+
+def handleNameInputPipe(name: SignallingRef[IO, String]): Pipe[IO, Event, Unit] =
+  _.evalMap { event =>
+    IO {
+      val inputValue = event.target.asInstanceOf[HTMLInputElement].value
+      val newValue = if inputValue.isEmpty then "world" else inputValue
+      name.set(newValue).unsafeRunAsync(_ => ())
+    }
+  }
+
+val handleClickPipe: Pipe[IO, Event, Unit] =
+  _.evalMap(e =>
+    IO(
+      println(
+        s"Clicked on element with class: ${e.target.asInstanceOf[HTMLElement].className}"
+      )
+    ))
+
+object Sandbox extends IOWebApp {
+  def render: Resource[IO, HtmlDivElement[IO]] =
+    SignallingRef[IO].of("world").toResource.flatMap { name =>
+      Resource.eval {
+        for {
+          container <- ccdivTag(
+            classAttr := "app-container",
+            onClickAttr --> handleClickPipe
+          )
+          label <- cclabelTag(labelTextAttr := "Your name: ")
+          _ <- appendChild(container, label)
+          input <- ccinputTag(
+            idAttr := "name-input",
+            placeholderAttr := "Enter your name here",
+            onInputAttr --> handleNameInputPipe(name)
+          )
+          _ <- appendChild(container, input)
+          greetingDiv <- ccdivTag()
+          _ <- appendChild(container, greetingDiv)
+          _ <- IO {
+            name
+              .discrete
+              .map(value => s"Hello, ${value.toUpperCase}")
+              .evalMap(greeting =>
+                IO(
+                  greetingDiv.asInstanceOf[HTMLElement].textContent = greeting
+                ))
+              .compile
+              .drain
+              .unsafeRunAndForget()
+          }
+        } yield container.asInstanceOf[HtmlDivElement[
+          IO
+        ]]
+      }
+    }
+}

--- a/sandbox/src/main/scala/calico/Sandbox.scala
+++ b/sandbox/src/main/scala/calico/Sandbox.scala
@@ -1,13 +1,32 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import calico.*
 import calico.html.CustomComponent.{*, given}
-import calico.unsafe.given
 import calico.syntax.*
+import calico.unsafe.given
 import cats.effect.*
+import cats.syntax.all.*
 import fs2.*
 import fs2.concurrent.*
 import fs2.dom.*
-import org.scalajs.dom.{document, Event, HTMLElement, HTMLInputElement}
-import cats.syntax.all.*
+import org.scalajs.dom.Event
+import org.scalajs.dom.HTMLElement
+import org.scalajs.dom.HTMLInputElement
+import org.scalajs.dom.document
 
 val placeholderAttr = Attribute[ccinputElem, String]("placeholder")
 val labelTextAttr = Attribute[cclabelElem, String]("textContent")


### PR DESCRIPTION
This PR is an attempt to improve the DSL (the custom HTML DSL) for Calico, aligning with #180’s vision for ergonomic, type-safe, and reactive UI composition, with partial support for web components (#37).

### Changes Done





- Type-Safe Elements: restrict `Attribute[E, V]` and `Setter[E, A, V]` to specific element types which is  enforced at compile time.



- Reactive Bindings: `Attribute[E, V]` supports `:=, -->, <--` with` Signal[IO, V]` and P`ipe[IO, Event, Nothing].`

- Web Components: enables custom web components by allowing `Tag[customElem]` to create <my-custom-element> with type-safe `customValueAttr` and `onValueChangedAttr` for props and events.

- FP-Friendly: IO and Resource for DOM ops, with fs2 streams for events.


 ###  **Limitations / Future Work**





- Incomplete Purity: Emits uses unsafeRunSync stub; needs proper cleanup.
 
- Limited Attributes: Missing valueAttr, styleAttr for some tags.

- No Calico Core Integration: DSL is standalone, not tied to Calico’s HtmlElement[IO].

- Basic Web Components: cccustomTag lacks full props/events support
- No Svg support as of now.