### PR TITLE
feat: simplify parametric HTML DSL with automatic Html[F] derivation …

### DIFF
--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2022 Arman Bilge
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -1,12 +1,15 @@
 /*
  * Copyright 2022 Arman Bilge
  *
+
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
+
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +29,15 @@ object io extends Html[IO]
 
 object Html:
   def apply[F[_]: Async]: Html[F] = new Html[F]
+
+  /** Automatically derives an [[Html]] capability for any effect type with an [[Async]]
+    * instance.
+    *
+    * This allows parametric components to request the HTML DSL via a context bound:
+    * {{{[F[_]: Async: Html]}}} or a using clause: {{{(using Html[F])}}} rather than
+    * threading an explicit `Html[F]` instance through every call.
+    */
+  given [F[_]: Async]: Html[F] = new Html[F]
 
 sealed class Html[F[_]](using F: Async[F])
     extends HtmlTags[F],

--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2022 Arman Bilge
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,13 +27,14 @@ object io extends Html[IO]
 object Html:
   def apply[F[_]: Async]: Html[F] = new Html[F]
 
-  /** Automatically derives an [[Html]] capability for any effect type with an [[Async]]
-    * instance.
-    *
-    * This allows parametric components to request the HTML DSL via a context bound:
-    * {{{[F[_]: Async: Html]}}} or a using clause: {{{(using Html[F])}}} rather than
-    * threading an explicit `Html[F]` instance through every call.
-    */
+  /**
+   * Automatically derives an [[Html]] capability for any effect type with an [[Async]]
+   * instance.
+   *
+   * This allows parametric components to request the HTML DSL via a context bound:
+   * {{{[F[_]: Async: Html]}}} or a using clause: {{{(using Html[F])}}} rather than threading an
+   * explicit `Html[F]` instance through every call.
+   */
   given [F[_]: Async]: Html[F] = new Html[F]
 
 sealed class Html[F[_]](using F: Async[F])

--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -1,15 +1,12 @@
 /*
  * Copyright 2022 Arman Bilge
  *
-
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
-
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
-
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2022 Arman Bilge
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2022 Arman Bilge
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -1,12 +1,15 @@
 /*
  * Copyright 2022 Arman Bilge
  *
+
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
+
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,10 +19,12 @@
 
 package not.calico
 
+import calico.html.Html
 import calico.html.io.*
 import calico.html.io.given
 import calico.syntax.*
 import cats.effect.*
+import cats.effect.kernel.Async
 import cats.syntax.all.*
 import fs2.concurrent.*
 
@@ -45,3 +50,15 @@ class SyntaxSuite:
       onClick(_ => IO.unit),
       onClick(IO.unit)
     )
+
+  // verify fix for issue #461: Html DSL works for parametric F[_] without per-scope import
+  // of an Html instance.
+  // Previously users had to write:
+  // def foo[F[_]: Async](using h: Html[F]) = { import h.{*, given}; div(...) }
+  // Now, given Html[F] is automatically derived from Async[F], so users can write
+  // [F[_]: Async: Html] and import from the summon'd instance once at the method level.
+  def parametricComponent[F[_]: Async: Html](
+      text: String): Resource[F, fs2.dom.HtmlElement[F]] =
+    val h = summon[Html[F]]
+    import h.{*, given}
+    div(span(text))

--- a/calico/src/test/scala/calico/SyntaxSuite.scala
+++ b/calico/src/test/scala/calico/SyntaxSuite.scala
@@ -1,15 +1,12 @@
 /*
  * Copyright 2022 Arman Bilge
  *
-
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
-
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
-
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -14,8 +14,25 @@ import fs2.dom.*
 val component: Resource[IO, HtmlElement[IO]] = ???
 
 // or more generally:
-def component[F[_]: Dom]: Resource[F, HtmlElement[F]] = ???
+def component[F[_]: Async: Html]: Resource[F, HtmlElement[F]] =
+  div("Hello from a parametric component!")
 ```
+
+The `Async` capability is required to run effects, while `Html` provides the DSL for describing elements. By requesting `Html` as a context bound, you can access all standard HTML tags and attributes within your component.
+
+Previously, using Calico with parametric effect types required manually threading and importing an `Html[F]` instance. Now, an `Html[F]` capability is automatically derived for any effect type with an `Async` instance.
+
+```scala
+import calico.html.*
+import cats.effect.kernel.Async
+
+def myParametricComponent[F[_]: Async: Html]: Resource[F, HtmlElement[F]] =
+  div(
+    "This is a parametric component",
+    cls := "my-class"
+  )
+```
+
 
 This `Resource` completely manages the lifecycle of that element and its children. When the `Resource` is allocated, it will create an instance of the `HtmlElement` and any supporting resources, such as background `Fiber`s or WebSocket connections. In kind, when the `Resource` is closed, these `Fiber`s and connections are canceled and released.
 


### PR DESCRIPTION
This PR addresses issue #461 by simplifying the usage of Calico's HTML DSL in parametric (effect-polymorphic) code.

Currently, users working with a parametric effect F[_]: Async must manually pass an Html[F] capability and import from it in every function scope, which creates significant boilerplate. This change introduces an automatic derivation for the Html[F] capability, allowing it to be synthesized directly from an Async[F] instance.

Key Changes
Automatic Derivation: Added given [F[_]: Async]: Html[F] = new Html[F] to the Html companion object. This makes Html[F] available for any effect type that has an Async instance.
Ergonomic Pattern: Enables the use of context bounds to request the DSL: def component[F[_]: Async: Html].
Documentation: Updated 
docs/concepts.md
 to highlight the simplified parametric usage pattern.
Verification: Added a compile-time test case in 
SyntaxSuite.scala
 ensuring that parametric components correctly type-check using the new pattern.