### PR TITLE
redesign encoding of dsl element with phantom types 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.2"
+ThisBuild / tlBaseVersion := "0.3"
 
 ThisBuild / organization := "com.armanbilge"
 ThisBuild / organizationName := "Arman Bilge"

--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -34,6 +34,7 @@ sealed class Html[F[_]](using F: Async[F])
       DocumentEventProps[F],
       WindowEventProps[F],
       HtmlAttrs[F],
+      GeneratedValidInstances[F],
       PropModifiers[F],
       EventPropModifiers[F],
       ClassPropModifiers[F],
@@ -44,24 +45,34 @@ sealed class Html[F[_]](using F: Async[F])
 
   given Dom[F] = Dom.forAsync
 
+  inline given validAttr_rel: ValidAttr["rel", fs2.dom.HtmlElement[F]] = ValidAttr.instance
+  inline given validAttr_role: ValidAttr["role", fs2.dom.HtmlElement[F]] = ValidAttr.instance
+  inline given validAttr_style: ValidAttr["style", fs2.dom.HtmlElement[F]] = ValidAttr.instance
+  inline given validAttr_value: ValidAttr["value", fs2.dom.HtmlElement[F]] = ValidAttr.instance
+  inline given validAttr_data: ValidAttr[Any, fs2.dom.HtmlElement[F]] = ValidAttr.instance
+  inline given validProp_className: ValidProp["className", fs2.dom.HtmlElement[F]] =
+    ValidProp.instance
+
   def aria: Aria[F] = Aria[F]
 
   def cls: ClassProp[F] = ClassProp[F]
 
-  def rel: HtmlAttr[F, List[String]] = HtmlAttr("rel", encoders.whitespaceSeparatedStrings)
+  def rel: HtmlAttr[F, "rel", List[String]] =
+    new HtmlAttr("rel", encoders.whitespaceSeparatedStrings)
 
-  def role: HtmlAttr[F, List[String]] = HtmlAttr("role", encoders.whitespaceSeparatedStrings)
+  def role: HtmlAttr[F, "role", List[String]] =
+    new HtmlAttr("role", encoders.whitespaceSeparatedStrings)
 
-  def dataAttr(suffix: String): HtmlAttr[F, String] =
-    HtmlAttr("data-" + suffix, encoders.identity)
+  def dataAttr(suffix: String): HtmlAttr[F, Any, String] =
+    new HtmlAttr("data-" + suffix, encoders.identity)
 
   def children: Children[F] = Children[F]
 
   def children[K](f: K => Resource[F, fs2.dom.Node[F]]): KeyedChildren[F, K] =
     KeyedChildren[F, K](f)
 
-  def styleAttr: HtmlAttr[F, String] =
-    HtmlAttr("style", encoders.identity)
+  def styleAttr: HtmlAttr[F, "style", String] =
+    new HtmlAttr("style", encoders.identity)
 
-  def valueAttr: HtmlAttr[F, String] =
-    HtmlAttr("value", encoders.identity)
+  def valueAttr: HtmlAttr[F, "value", String] =
+    new HtmlAttr("value", encoders.identity)

--- a/calico/src/main/scala/calico/html/HtmlAttr.scala
+++ b/calico/src/main/scala/calico/html/HtmlAttr.scala
@@ -23,113 +23,122 @@ import cats.effect.kernel.Resource
 import fs2.concurrent.Signal
 import org.scalajs.dom
 
-sealed class HtmlAttr[F[_], V] private[calico] (key: String, encode: V => String):
+sealed class HtmlAttr[F[_], A, V] private[calico] (key: String, encode: V => String):
   import HtmlAttr.*
 
-  @inline def :=(v: V): ConstantModifier[V] =
+  @inline def :=(v: V): ConstantModifier[A, V] =
     ConstantModifier(key, encode, v)
 
-  @inline def <--(vs: Signal[F, V]): SignalModifier[F, V] =
+  @inline def <--(vs: Signal[F, V]): SignalModifier[A, F, V] =
     SignalModifier(key, encode, vs)
 
-  @inline def <--(vs: Resource[F, Signal[F, V]]): SignalResourceModifier[F, V] =
+  @inline def <--(vs: Resource[F, Signal[F, V]]): SignalResourceModifier[A, F, V] =
     SignalResourceModifier(key, encode, vs)
 
-  @inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[F, V] =
+  @inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[A, F, V] =
     OptionSignalModifier(key, encode, vs)
 
-  @inline def <--(vs: Resource[F, Signal[F, Option[V]]]): OptionSignalResourceModifier[F, V] =
+  @inline def <--(
+      vs: Resource[F, Signal[F, Option[V]]]): OptionSignalResourceModifier[A, F, V] =
     OptionSignalResourceModifier(key, encode, vs)
 
-  @inline def contramap[U](f: U => V): HtmlAttr[F, U] =
+  @inline def contramap[U](f: U => V): HtmlAttr[F, A, U] =
     new HtmlAttr(key, f.andThen(encode))
 
 object HtmlAttr:
-  inline given [F[_]]: Contravariant[HtmlAttr[F, _]] =
-    _contravariant.asInstanceOf[Contravariant[HtmlAttr[F, _]]]
-  private val _contravariant: Contravariant[HtmlAttr[Id, _]] = new:
-    def contramap[A, B](fa: HtmlAttr[Id, A])(f: B => A): HtmlAttr[Id, B] =
+  inline given [F[_], A]: Contravariant[HtmlAttr[F, A, _]] =
+    _contravariant.asInstanceOf[Contravariant[HtmlAttr[F, A, _]]]
+  private val _contravariant: Contravariant[HtmlAttr[Id, Any, _]] = new:
+    def contramap[X, Y](fa: HtmlAttr[Id, Any, X])(f: Y => X): HtmlAttr[Id, Any, Y] =
       fa.contramap(f)
 
-  final class ConstantModifier[V] private[calico] (
+  final class ConstantModifier[A, V] private[calico] (
       private[calico] val key: String,
       private[calico] val encode: V => String,
       private[calico] val value: V
   )
 
-  final class SignalModifier[F[_], V] private[calico] (
+  final class SignalModifier[A, F[_], V] private[calico] (
       private[calico] val key: String,
       private[calico] val encode: V => String,
       private[calico] val values: Signal[F, V]
   )
 
-  final class SignalResourceModifier[F[_], V] private[calico] (
+  final class SignalResourceModifier[A, F[_], V] private[calico] (
       private[calico] val key: String,
       private[calico] val encode: V => String,
       private[calico] val values: Resource[F, Signal[F, V]]
   )
 
-  final class OptionSignalModifier[F[_], V] private[calico] (
+  final class OptionSignalModifier[A, F[_], V] private[calico] (
       private[calico] val key: String,
       private[calico] val encode: V => String,
       private[calico] val values: Signal[F, Option[V]]
   )
 
-  final class OptionSignalResourceModifier[F[_], V] private[calico] (
+  final class OptionSignalResourceModifier[A, F[_], V] private[calico] (
       private[calico] val key: String,
       private[calico] val encode: V => String,
       private[calico] val values: Resource[F, Signal[F, Option[V]]]
   )
 
-private trait HtmlAttrModifiers[F[_]](using F: Async[F]):
+private[calico] trait HtmlAttrModifiers[F[_]](using F: Async[F]):
   import HtmlAttr.*
 
-  inline given forConstantHtmlAttr[E <: fs2.dom.Element[F], V]
-      : Modifier[F, E, ConstantModifier[V]] =
-    _forConstantHtmlAttr.asInstanceOf[Modifier[F, E, ConstantModifier[V]]]
+  inline given forConstantHtmlAttr[A, E <: fs2.dom.HtmlElement[F], V](
+      using ValidAttr[A, E]
+  ): Modifier[F, E, ConstantModifier[A, V]] =
+    _forConstantHtmlAttr.asInstanceOf[Modifier[F, E, ConstantModifier[A, V]]]
 
-  private val _forConstantHtmlAttr: Modifier[F, dom.Element, ConstantModifier[Any]] =
+  private val _forConstantHtmlAttr: Modifier[F, dom.Element, ConstantModifier[Any, Any]] =
     (m, e) => Resource.eval(F.delay(e.setAttribute(m.key, m.encode(m.value))))
 
-  inline given forSignalHtmlAttr[E <: fs2.dom.Element[F], V]
-      : Modifier[F, E, SignalModifier[F, V]] =
-    _forSignalHtmlAttr.asInstanceOf[Modifier[F, E, SignalModifier[F, V]]]
+  inline given forSignalHtmlAttr[A, E <: fs2.dom.HtmlElement[F], V](
+      using ValidAttr[A, E]
+  ): Modifier[F, E, SignalModifier[A, F, V]] =
+    _forSignalHtmlAttr.asInstanceOf[Modifier[F, E, SignalModifier[A, F, V]]]
 
   private val _forSignalHtmlAttr =
-    Modifier.forSignal[F, dom.Element, SignalModifier[F, Any], Any](_.values) { (m, e) => v =>
-      F.delay(e.setAttribute(m.key, m.encode(v)))
-    }
-
-  inline given forSignalResourceHtmlAttr[E <: fs2.dom.Element[F], V]
-      : Modifier[F, E, SignalResourceModifier[F, V]] =
-    _forSignalResourceHtmlAttr.asInstanceOf[Modifier[F, E, SignalResourceModifier[F, V]]]
-
-  private val _forSignalResourceHtmlAttr =
-    Modifier.forSignalResource[F, dom.Element, SignalResourceModifier[F, Any], Any](_.values) {
+    Modifier.forSignal[F, dom.Element, SignalModifier[Any, F, Any], Any](_.values) {
       (m, e) => v => F.delay(e.setAttribute(m.key, m.encode(v)))
     }
 
-  inline given forOptionSignalHtmlAttr[E <: fs2.dom.Element[F], V]
-      : Modifier[F, E, OptionSignalModifier[F, V]] =
-    _forOptionSignalHtmlAttr.asInstanceOf[Modifier[F, E, OptionSignalModifier[F, V]]]
+  inline given forSignalResourceHtmlAttr[A, E <: fs2.dom.HtmlElement[F], V](
+      using ValidAttr[A, E]
+  ): Modifier[F, E, SignalResourceModifier[A, F, V]] =
+    _forSignalResourceHtmlAttr.asInstanceOf[Modifier[F, E, SignalResourceModifier[A, F, V]]]
+
+  private val _forSignalResourceHtmlAttr =
+    Modifier.forSignalResource[F, dom.Element, SignalResourceModifier[Any, F, Any], Any](
+      _.values) { (m, e) => v => F.delay(e.setAttribute(m.key, m.encode(v))) }
+
+  inline given forOptionSignalHtmlAttr[A, E <: fs2.dom.HtmlElement[F], V](
+      using ValidAttr[A, E]
+  ): Modifier[F, E, OptionSignalModifier[A, F, V]] =
+    _forOptionSignalHtmlAttr.asInstanceOf[Modifier[F, E, OptionSignalModifier[A, F, V]]]
 
   private val _forOptionSignalHtmlAttr =
-    Modifier.forSignal[F, dom.Element, OptionSignalModifier[F, Any], Option[Any]](_.values) {
-      (m, e) => v =>
-        F.delay(v.fold(e.removeAttribute(m.key))(v => e.setAttribute(m.key, m.encode(v))))
+    Modifier.forSignal[F, dom.Element, OptionSignalModifier[Any, F, Any], Option[Any]](
+      _.values) { (m, e) => v =>
+      F.delay(v.fold(e.removeAttribute(m.key))(v => e.setAttribute(m.key, m.encode(v))))
     }
 
-  inline given forOptionSignalResourceHtmlAttr[E <: fs2.dom.Element[F], V]
-      : Modifier[F, E, OptionSignalResourceModifier[F, V]] =
+  inline given forOptionSignalResourceHtmlAttr[A, E <: fs2.dom.HtmlElement[F], V](
+      using ValidAttr[A, E]
+  ): Modifier[F, E, OptionSignalResourceModifier[A, F, V]] =
     _forOptionSignalResourceHtmlAttr
-      .asInstanceOf[Modifier[F, E, OptionSignalResourceModifier[F, V]]]
+      .asInstanceOf[Modifier[F, E, OptionSignalResourceModifier[A, F, V]]]
 
   private val _forOptionSignalResourceHtmlAttr =
-    Modifier
-      .forSignalResource[F, dom.Element, OptionSignalResourceModifier[F, Any], Option[Any]](
-        _.values) { (m, e) => v =>
-        F.delay(v.fold(e.removeAttribute(m.key))(v => e.setAttribute(m.key, m.encode(v))))
-      }
+    Modifier.forSignalResource[
+      F,
+      dom.Element,
+      OptionSignalResourceModifier[Any, F, Any],
+      Option[
+        Any
+      ]](_.values) { (m, e) => v =>
+      F.delay(v.fold(e.removeAttribute(m.key))(v => e.setAttribute(m.key, m.encode(v))))
+    }
 
 final class Aria[F[_]] private extends AriaAttrs[F]
 
@@ -137,5 +146,5 @@ private object Aria:
   inline def apply[F[_]]: Aria[F] = instance.asInstanceOf[Aria[F]]
   private val instance: Aria[cats.Id] = new Aria[cats.Id]
 
-final class AriaAttr[F[_], V] private[calico] (suffix: String, encode: V => String)
-    extends HtmlAttr[F, V]("aria-" + suffix, encode)
+final class AriaAttr[F[_], A, V] private[calico] (suffix: String, encode: V => String)
+    extends HtmlAttr[F, A, V]("aria-" + suffix, encode)

--- a/calico/src/main/scala/calico/html/Prop.scala
+++ b/calico/src/main/scala/calico/html/Prop.scala
@@ -33,66 +33,66 @@ import org.scalajs.dom
 import scala.annotation.targetName
 import scala.scalajs.js
 
-sealed class Prop[F[_], V, J] private[calico] (name: String, encode: V => J):
+sealed class Prop[F[_], A, V, J] private[calico] (name: String, encode: V => J):
   import Prop.*
 
-  @inline def :=(v: V): ConstantModifier[V, J] =
+  @inline def :=(v: V): ConstantModifier[A, V, J] =
     ConstantModifier(name, encode, v)
 
-  @inline def <--(vs: Signal[F, V]): SignalModifier[F, V, J] =
+  @inline def <--(vs: Signal[F, V]): SignalModifier[A, F, V, J] =
     SignalModifier(name, encode, vs)
 
-  @inline def <--(vs: Resource[F, Signal[F, V]]): SignalResourceModifier[F, V, J] =
+  @inline def <--(vs: Resource[F, Signal[F, V]]): SignalResourceModifier[A, F, V, J] =
     SignalResourceModifier(name, encode, vs)
 
-  @inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[F, V, J] =
+  @inline def <--(vs: Signal[F, Option[V]]): OptionSignalModifier[A, F, V, J] =
     OptionSignalModifier(name, encode, vs)
 
   @inline def <--(
-      vs: Resource[F, Signal[F, Option[V]]]): OptionSignalResourceModifier[F, V, J] =
+      vs: Resource[F, Signal[F, Option[V]]]): OptionSignalResourceModifier[A, F, V, J] =
     OptionSignalResourceModifier(name, encode, vs)
 
-  @inline def contramap[U](f: U => V): Prop[F, U, J] =
+  @inline def contramap[U](f: U => V): Prop[F, A, U, J] =
     new Prop(name, f.andThen(encode))
 
 object Prop:
-  inline given [F[_], J]: Contravariant[Prop[F, _, J]] =
-    _contravariant.asInstanceOf[Contravariant[Prop[F, _, J]]]
-  private val _contravariant: Contravariant[Prop[Id, _, Any]] = new:
-    def contramap[A, B](fa: Prop[Id, A, Any])(f: B => A): Prop[Id, B, Any] =
+  inline given [F[_], A, J]: Contravariant[Prop[F, A, _, J]] =
+    _contravariant.asInstanceOf[Contravariant[Prop[F, A, _, J]]]
+  private val _contravariant: Contravariant[Prop[Id, Any, _, Any]] = new:
+    def contramap[X, Y](fa: Prop[Id, Any, X, Any])(f: Y => X): Prop[Id, Any, Y, Any] =
       fa.contramap(f)
 
-  final class ConstantModifier[V, J] private[calico] (
+  final class ConstantModifier[A, V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val encode: V => J,
       private[calico] val value: V
   )
 
-  final class SignalModifier[F[_], V, J] private[calico] (
+  final class SignalModifier[A, F[_], V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val encode: V => J,
       private[calico] val values: Signal[F, V]
   )
 
-  final class SignalResourceModifier[F[_], V, J] private[calico] (
+  final class SignalResourceModifier[A, F[_], V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val encode: V => J,
       private[calico] val values: Resource[F, Signal[F, V]]
   )
 
-  final class OptionSignalModifier[F[_], V, J] private[calico] (
+  final class OptionSignalModifier[A, F[_], V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val encode: V => J,
       private[calico] val values: Signal[F, Option[V]]
   )
 
-  final class OptionSignalResourceModifier[F[_], V, J] private[calico] (
+  final class OptionSignalResourceModifier[A, F[_], V, J] private[calico] (
       private[calico] val name: String,
       private[calico] val encode: V => J,
       private[calico] val values: Resource[F, Signal[F, Option[V]]]
   )
 
-private trait PropModifiers[F[_]](using F: Async[F]):
+private[calico] trait PropModifiers[F[_]](using F: Async[F]):
   import Prop.*
 
   private inline def setProp[N, V, J](node: N, name: String, encode: V => J) =
@@ -110,44 +110,57 @@ private trait PropModifiers[F[_]](using F: Async[F]):
         ()
       }
 
-  inline given forConstantProp[N, V, J]: Modifier[F, N, ConstantModifier[V, J]] =
-    _forConstantProp.asInstanceOf[Modifier[F, N, ConstantModifier[V, J]]]
+  inline given forConstantProp[A, N, V, J](
+      using ValidProp[A, N]
+  ): Modifier[F, N, ConstantModifier[A, V, J]] =
+    _forConstantProp.asInstanceOf[Modifier[F, N, ConstantModifier[A, V, J]]]
 
-  private val _forConstantProp: Modifier[F, Any, ConstantModifier[Any, Any]] =
+  private val _forConstantProp: Modifier[F, Any, ConstantModifier[Any, Any, Any]] =
     (m, n) => Resource.eval(setProp(n, m.name, m.encode).apply(m.value))
 
-  inline given forSignalProp[N, V, J]: Modifier[F, N, SignalModifier[F, V, J]] =
-    _forSignalProp.asInstanceOf[Modifier[F, N, SignalModifier[F, V, J]]]
+  inline given forSignalProp[A, N, V, J](
+      using ValidProp[A, N]
+  ): Modifier[F, N, SignalModifier[A, F, V, J]] =
+    _forSignalProp.asInstanceOf[Modifier[F, N, SignalModifier[A, F, V, J]]]
 
   private val _forSignalProp =
-    Modifier.forSignal[F, Any, SignalModifier[F, Any, Any], Any](_.values) { (m, n) =>
+    Modifier.forSignal[F, Any, SignalModifier[Any, F, Any, Any], Any](_.values) { (m, n) =>
       setProp(n, m.name, m.encode)
     }
 
-  inline given forSignalResourceProp[N, V, J]: Modifier[F, N, SignalResourceModifier[F, V, J]] =
-    _forSignalResourceProp.asInstanceOf[Modifier[F, N, SignalResourceModifier[F, V, J]]]
+  inline given forSignalResourceProp[A, N, V, J](
+      using ValidProp[A, N]
+  ): Modifier[F, N, SignalResourceModifier[A, F, V, J]] =
+    _forSignalResourceProp.asInstanceOf[Modifier[F, N, SignalResourceModifier[A, F, V, J]]]
 
   private val _forSignalResourceProp =
-    Modifier.forSignalResource[F, Any, SignalResourceModifier[F, Any, Any], Any](_.values) {
-      (m, n) => setProp(n, m.name, m.encode)
-    }
+    Modifier.forSignalResource[F, Any, SignalResourceModifier[Any, F, Any, Any], Any](
+      _.values) { (m, n) => setProp(n, m.name, m.encode) }
 
-  inline given forOptionSignalProp[N, V, J]: Modifier[F, N, OptionSignalModifier[F, V, J]] =
-    _forOptionSignalProp.asInstanceOf[Modifier[F, N, OptionSignalModifier[F, V, J]]]
+  inline given forOptionSignalProp[A, N, V, J](
+      using ValidProp[A, N]
+  ): Modifier[F, N, OptionSignalModifier[A, F, V, J]] =
+    _forOptionSignalProp.asInstanceOf[Modifier[F, N, OptionSignalModifier[A, F, V, J]]]
 
   private val _forOptionSignalProp =
-    Modifier.forSignal[F, Any, OptionSignalModifier[F, Any, Any], Option[Any]](_.values) {
+    Modifier.forSignal[F, Any, OptionSignalModifier[Any, F, Any, Any], Option[Any]](_.values) {
       (m, n) => setPropOption(n, m.name, m.encode)
     }
 
-  inline given forOptionSignalResourceProp[N, V, J]
-      : Modifier[F, N, OptionSignalResourceModifier[F, V, J]] =
+  inline given forOptionSignalResourceProp[A, N, V, J](
+      using ValidProp[A, N]
+  ): Modifier[F, N, OptionSignalResourceModifier[A, F, V, J]] =
     _forOptionSignalResourceProp
-      .asInstanceOf[Modifier[F, N, OptionSignalResourceModifier[F, V, J]]]
+      .asInstanceOf[Modifier[F, N, OptionSignalResourceModifier[A, F, V, J]]]
 
   private val _forOptionSignalResourceProp =
-    Modifier.forSignalResource[F, Any, OptionSignalResourceModifier[F, Any, Any], Option[Any]](
-      _.values) { (m, n) => setPropOption(n, m.name, m.encode) }
+    Modifier.forSignalResource[
+      F,
+      Any,
+      OptionSignalResourceModifier[Any, F, Any, Any],
+      Option[
+        Any
+      ]](_.values) { (m, n) => setPropOption(n, m.name, m.encode) }
 
 final class EventProp[F[_], A] private[calico] (key: String, pipe: Pipe[F, Any, A]):
   import EventProp.*
@@ -194,7 +207,7 @@ private trait EventPropModifiers[F[_]](using F: Async[F]):
     (m, t) => (F.cede *> fs2.dom.events(t, m.key).through(m.sink).compile.drain).background.void
 
 final class ClassProp[F[_]] private[calico]
-    extends Prop[F, List[String], String](
+    extends Prop[F, "className", List[String], String](
       "className",
       encoders.whitespaceSeparatedStrings
     ):

--- a/calico/src/main/scala/calico/html/ValidAttr.scala
+++ b/calico/src/main/scala/calico/html/ValidAttr.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.html
+
+/**
+ * Evidence that an attribute identified by phantom type `A` is valid on element type `E`.
+ * Contravariant in `E` so that if an attribute is valid on `HtmlElement`,
+ * it is also valid on all subtypes (e.g. `HtmlInputElement`).
+ */
+trait ValidAttr[A, -E]
+
+object ValidAttr:
+  private val _instance: ValidAttr[Any, Any] = new ValidAttr[Any, Any] {}
+  inline def instance[A, E]: ValidAttr[A, E] = _instance.asInstanceOf[ValidAttr[A, E]]
+
+/**
+ * Evidence that a property identified by phantom type `A` is valid on element type `E`.
+ * Contravariant in `E` for the same reason as `ValidAttr`.
+ */
+trait ValidProp[A, -E]
+
+object ValidProp:
+  private val _instance: ValidProp[Any, Any] = new ValidProp[Any, Any] {}
+  inline def instance[A, E]: ValidProp[A, E] = _instance.asInstanceOf[ValidProp[A, E]]

--- a/calico/src/main/scala/calico/html/ValidAttr.scala
+++ b/calico/src/main/scala/calico/html/ValidAttr.scala
@@ -15,22 +15,12 @@
  */
 
 package calico.html
-
-/**
- * Evidence that an attribute identified by phantom type `A` is valid on element type `E`.
- * Contravariant in `E` so that if an attribute is valid on `HtmlElement`,
- * it is also valid on all subtypes (e.g. `HtmlInputElement`).
- */
 trait ValidAttr[A, -E]
 
 object ValidAttr:
   private val _instance: ValidAttr[Any, Any] = new ValidAttr[Any, Any] {}
   inline def instance[A, E]: ValidAttr[A, E] = _instance.asInstanceOf[ValidAttr[A, E]]
 
-/**
- * Evidence that a property identified by phantom type `A` is valid on element type `E`.
- * Contravariant in `E` for the same reason as `ValidAttr`.
- */
 trait ValidProp[A, -E]
 
 object ValidProp:

--- a/docs/demos/http4s.md
+++ b/docs/demos/http4s.md
@@ -27,10 +27,10 @@ object Repo:
   given EntityDecoder[IO, Repo] = jsonOf
 
 val client = FetchClientBuilder[IO].create
-
+  
 val app: Resource[IO, HtmlDivElement[IO]] = (
   input(size := 36, typ := "text", value := "armanbilge/calico"),
-  SignallingRef[IO].of("").toResource
+  SignallingRef[IO].of  ("").toResource
 ).flatMapN { (repoInput, starsResult) =>
 
   val countStars: IO[Unit] =

--- a/project/src/main/scala/calico/html/codegen/CalicoGenerator.scala
+++ b/project/src/main/scala/calico/html/codegen/CalicoGenerator.scala
@@ -169,7 +169,6 @@ private[codegen] class CalicoGenerator(srcManaged: File)
 
     for (d <- defs) {
       val codecExpr = transformCodecName(d.codec)
-      // domName has aria- stripped already by transformAttrDomName in DomDefsGenerator
       val suffix = d.domName
       val scalaName = d.scalaName
       val valueType = d.scalaValueType
@@ -230,7 +229,6 @@ private[codegen] class CalicoGenerator(srcManaged: File)
     standardTraitCommentLines.foreach(c => sb.append(s"// $c\n"))
     sb.append(s"\nprivate trait GeneratedValidInstances[F[_]](using Async[F]):\n\n")
 
-    // ValidAttr instances for HTML attributes
     for (d <- htmlAttrDefs) {
       val domName = d.domName
       val safeName = sanitizeName(d.scalaName)
@@ -245,7 +243,7 @@ private[codegen] class CalicoGenerator(srcManaged: File)
     sb.append("\n")
 
     for (d <- ariaAttrDefs) {
-      val suffix = d.domName // already has aria- stripped
+      val suffix = d.domName
       val fullName = "aria-" + suffix
       val safeName = sanitizeName(d.scalaName)
       sb.append(

--- a/project/src/main/scala/calico/html/codegen/CalicoGenerator.scala
+++ b/project/src/main/scala/calico/html/codegen/CalicoGenerator.scala
@@ -122,6 +122,152 @@ private[codegen] class CalicoGenerator(srcManaged: File)
     ).printTrait().getOutput()
   }
 
+  def generatePhantomHtmlAttrsTrait(
+      defGroups: List[(String, List[AttrDef])],
+      traitName: String
+  ): String = {
+    val defs = defGroups.flatMap(_._2)
+    val sb = new StringBuilder
+
+    sb.append(s"package $attrDefsPackagePath\n\n")
+    standardTraitCommentLines.foreach(c => sb.append(s"// $c\n"))
+    sb.append(s"\nprivate trait $traitName:\n\n")
+    sb.append(
+      s"  @inline private[calico] def htmlAttr[V](key: String, encode: V => String): HtmlAttr[F, key.type, V] =\n")
+    sb.append(s"    new HtmlAttr(key, encode)\n\n")
+
+    for (d <- defs) {
+      val codecExpr = transformCodecName(d.codec)
+      val domName = d.domName
+      val scalaName = d.scalaName
+      val valueType = d.scalaValueType
+      sb.append(
+        s"""  lazy val $scalaName: HtmlAttr[F, "$domName", $valueType] = htmlAttr("$domName", $codecExpr)\n""")
+      val aliases = d.scalaAliases
+      aliases.foreach { alias =>
+        sb.append(s"""  lazy val $alias: HtmlAttr[F, "$domName", $valueType] = $scalaName\n""")
+      }
+      sb.append("\n")
+    }
+
+    sb.toString
+  }
+
+  def generatePhantomAriaAttrsTrait(
+      defGroups: List[(String, List[AttrDef])],
+      traitName: String
+  ): String = {
+    val defs = defGroups.flatMap(_._2)
+    val sb = new StringBuilder
+
+    sb.append(s"package $attrDefsPackagePath\n\n")
+    standardTraitCommentLines.foreach(c => sb.append(s"// $c\n"))
+    sb.append(s"\nprivate trait $traitName:\n\n")
+    sb.append(
+      s"  @inline private[calico] def ariaAttr[V](key: String, encode: V => String): HtmlAttr[F, key.type, V] =\n")
+    sb.append(s"    new AriaAttr(key, encode)\n\n")
+
+    for (d <- defs) {
+      val codecExpr = transformCodecName(d.codec)
+      // domName has aria- stripped already by transformAttrDomName in DomDefsGenerator
+      val suffix = d.domName
+      val scalaName = d.scalaName
+      val valueType = d.scalaValueType
+      val fullName = "aria-" + suffix
+      sb.append(
+        s"""  lazy val $scalaName: HtmlAttr[F, "$fullName", $valueType] = ariaAttr("$fullName", $codecExpr)\n\n""")
+    }
+
+    sb.toString
+  }
+
+  def generatePhantomPropsTrait(
+      defGroups: List[(String, List[PropDef])],
+      traitName: String
+  ): String = {
+    val defs = defGroups.flatMap(_._2)
+    val sb = new StringBuilder
+
+    sb.append(s"package $propDefsPackagePath\n\n")
+    standardTraitCommentLines.foreach(c => sb.append(s"// $c\n"))
+    sb.append(s"\nprivate trait $traitName:\n\n")
+    sb.append(
+      s"  @inline private[calico] def prop[V, DomV](key: String, encode: V => DomV): Prop[F, key.type, V, DomV] =\n")
+    sb.append(s"    new Prop(key, encode)\n\n")
+
+    for (d <- defs) {
+      val codecExpr = transformCodecName(d.codec)
+      val domName = d.domName
+      val scalaName = d.scalaName
+      val valueType = d.scalaValueType
+      val domValueType = d.domValueType
+      sb.append(
+        s"""  lazy val $scalaName: Prop[F, "$domName", $valueType, $domValueType] = prop("$domName", $codecExpr)\n""")
+      val aliases = d.scalaAliases
+      aliases.foreach { alias =>
+        sb.append(
+          s"""  lazy val $alias: Prop[F, "$domName", $valueType, $domValueType] = $scalaName\n""")
+      }
+      sb.append("\n")
+    }
+
+    sb.toString
+  }
+
+  private def sanitizeName(scalaName: String): String =
+    scalaName.replace("`", "")
+
+  def generateValidInstances(
+      htmlAttrDefs: List[AttrDef],
+      ariaAttrDefs: List[AttrDef],
+      propDefs: List[PropDef]
+  ): String = {
+    val sb = new StringBuilder
+
+    sb.append(s"package $basePackagePath\n\n")
+    sb.append("import cats.effect.kernel.Async\n")
+    sb.append("import fs2.dom.*\n\n")
+    standardTraitCommentLines.foreach(c => sb.append(s"// $c\n"))
+    sb.append(s"\nprivate trait GeneratedValidInstances[F[_]](using Async[F]):\n\n")
+
+    // ValidAttr instances for HTML attributes
+    for (d <- htmlAttrDefs) {
+      val domName = d.domName
+      val safeName = sanitizeName(d.scalaName)
+      val bounds = ElementScopes.elementBoundsForAttr(safeName)
+      for (bound <- bounds) {
+        val givenName = s"validAttr_${safeName}_${bound.replace("[", "").replace("]", "")}"
+        sb.append(
+          s"""  inline given $givenName: ValidAttr["$domName", $bound[F]] = ValidAttr.instance\n""")
+      }
+    }
+
+    sb.append("\n")
+
+    for (d <- ariaAttrDefs) {
+      val suffix = d.domName // already has aria- stripped
+      val fullName = "aria-" + suffix
+      val safeName = sanitizeName(d.scalaName)
+      sb.append(
+        s"""  inline given validAttr_aria_$safeName: ValidAttr["$fullName", HtmlElement[F]] = ValidAttr.instance\n""")
+    }
+
+    sb.append("\n")
+
+    for (d <- propDefs) {
+      val domName = d.domName
+      val safeName = sanitizeName(d.scalaName)
+      val bounds = ElementScopes.elementBoundsForProp(safeName)
+      for (bound <- bounds) {
+        val givenName = s"validProp_${safeName}_${bound.replace("[", "").replace("]", "")}"
+        sb.append(
+          s"""  inline given $givenName: ValidProp["$domName", $bound[F]] = ValidProp.instance\n""")
+      }
+    }
+
+    sb.toString
+  }
+
   override def generateAttrsTrait(
       defGroups: List[(String, List[AttrDef])],
       printDefGroupComments: Boolean,

--- a/project/src/main/scala/calico/html/codegen/DomDefsGenerator.scala
+++ b/project/src/main/scala/calico/html/codegen/DomDefsGenerator.scala
@@ -51,8 +51,6 @@ object DomDefsGenerator {
         )
       }
 
-    // -- HTML tags --
-
     val htmlTags = {
       val traitName = "HtmlTags"
       val traitNameWithParams = s"$traitName[F[_]](using Async[F])"
@@ -83,185 +81,70 @@ object DomDefsGenerator {
       writeToFile(generator.tagDefsPackagePath, traitName, fileContent)
     }
 
-    // -- SVG tags --
-
-    // {
-    // val traitName = "SvgTags"
-
-    // val fileContent = generator.generateTagsTrait(
-    // tagType = SvgTagType,
-    // defGroups = defGroups.svgTagsDefGroups,
-    // printDefGroupComments = false,
-    // traitCommentLines = Nil,
-    // traitName = traitName,
-    // keyKind = "SvgTag",
-    // baseImplDefComments = List(
-    // "Create SVG tag",
-    // "",
-    // "Note: this simply creates an instance of HtmlTag.",
-    // " - This does not create the element (to do that, call .apply() on the returned tag instance)",
-    // "",
-    // "@param tagName - e.g. \"circle\"",
-    // "",
-    // "@tparam Ref    - type of elements with this tag, e.g. dom.svg.Circle for \"circle\" tag"
-    // ),
-    // keyImplName = "svgTag",
-    // defType = LazyVal
-    // )
-
-    // generator.writeToFile(
-    // packagePath = generator.tagDefsPackagePath,
-    // fileName = traitName,
-    // fileContent = fileContent
-    // )
-    // }
-
-    // -- HTML attributes --
+    val htmlAttrDefsList = defGroups.htmlAttrDefGroups.flatMap(_._2)
 
     val htmlAttrs = {
       val traitName = "HtmlAttrs"
-      val traitNameWithParams = s"$traitName[F[_]]"
 
-      val fileContent = generator.generateAttrsTrait(
-        defGroups = defGroups.htmlAttrDefGroups.map {
-          case (key, vals) =>
-            (key, vals.map(attr => attr.copy(scalaValueType = "F, " + attr.scalaValueType)))
-        },
-        printDefGroupComments = false,
-        traitCommentLines = Nil,
-        traitModifiers = List("private"),
-        traitName = traitNameWithParams,
-        keyKind = "HtmlAttr",
-        implNameSuffix = "HtmlAttr",
-        baseImplDefComments = List(
-          "Create HTML attribute (Note: for SVG attrs, use L.svg.svgAttr)",
-          "",
-          "@param key   - name of the attribute, e.g. \"value\"",
-          "@param codec - used to encode V into String, e.g. StringAsIsCodec",
-          "",
-          "@tparam V    - value type for this attr in Scala"
-        ),
-        baseImplName = "htmlAttr",
-        namespaceImports = Nil,
-        namespaceImpl = _ => ???,
-        transformAttrDomName = identity,
-        defType = LazyVal
+      val fileContent = generator.generatePhantomHtmlAttrsTrait(
+        defGroups = defGroups.htmlAttrDefGroups,
+        traitName = s"$traitName[F[_]]"
       )
 
       writeToFile(generator.attrDefsPackagePath, traitName, fileContent)
     }
 
-    // -- SVG attributes --
+    def transformAriaAttrDomName(ariaAttrName: String): String = {
+      if (ariaAttrName.startsWith("aria-")) {
+        ariaAttrName.substring(5)
+      } else {
+        throw new Exception(s"Aria attribute does not start with `aria-`: $ariaAttrName")
+      }
+    }
 
-    // {
-    // val traitName = "SvgAttrs"
-
-    // val fileContent = generator.generateAttrsTrait(
-    // defGroups = defGroups.svgAttrDefGroups,
-    // printDefGroupComments = false,
-    // traitName = traitName,
-    // traitCommentLines = Nil,
-    // keyKind = "SvgAttr",
-    // baseImplDefComments = List(
-    // "Create SVG attribute (Note: for HTML attrs, use L.htmlAttr)",
-    // "",
-    // "@param key   - name of the attribute, e.g. \"value\"",
-    // "@param codec - used to encode V into String, e.g. StringAsIsCodec",
-    // "",
-    // "@tparam V    - value type for this attr in Scala"
-    // ),
-    // implNameSuffix = "SvgAttr",
-    // baseImplName = "svgAttr",
-    // namespaceImports = Nil,
-    // namespaceImpl = SourceRepr(_),
-    // transformAttrDomName = identity,
-    // defType = LazyVal
-    // )
-
-    // generator.writeToFile(
-    // packagePath = generator.attrDefsPackagePath,
-    // fileName = traitName,
-    // fileContent = fileContent
-    // )
-    // }
-
-    // -- ARIA attributes --
+    val ariaAttrDefsList = defGroups
+      .ariaAttrDefGroups
+      .flatMap(_._2)
+      .map(d => d.copy(domName = transformAriaAttrDomName(d.domName)))
 
     val ariaAttrs = {
       val traitName = "AriaAttrs"
-      val traitNameWithParams = s"$traitName[F[_]]"
 
-      def transformAttrDomName(ariaAttrName: String): String = {
-        if (ariaAttrName.startsWith("aria-")) {
-          ariaAttrName.substring(5)
-        } else {
-          throw new Exception(s"Aria attribute does not start with `aria-`: $ariaAttrName")
-        }
-      }
-
-      val fileContent = generator.generateAttrsTrait(
+      val fileContent = generator.generatePhantomAriaAttrsTrait(
         defGroups = defGroups.ariaAttrDefGroups.map {
           case (key, vals) =>
-            (key, vals.map(attr => attr.copy(scalaValueType = "F, " + attr.scalaValueType)))
+            (key, vals.map(d => d.copy(domName = transformAriaAttrDomName(d.domName))))
         },
-        printDefGroupComments = false,
-        traitModifiers = List("private"),
-        traitName = traitNameWithParams,
-        traitCommentLines = Nil,
-        keyKind = "AriaAttr",
-        implNameSuffix = "AriaAttr",
-        baseImplDefComments = List(
-          "Create ARIA attribute (Note: for HTML attrs, use L.htmlAttr)",
-          "",
-          "@param key   - suffix of the attribute, without \"aria-\" prefix, e.g. \"labelledby\"",
-          "@param codec - used to encode V into String, e.g. StringAsIsCodec",
-          "",
-          "@tparam V    - value type for this attr in Scala"
-        ),
-        baseImplName = "ariaAttr",
-        namespaceImports = Nil,
-        namespaceImpl = _ => ???,
-        transformAttrDomName = transformAttrDomName,
-        defType = LazyVal
+        traitName = s"$traitName[F[_]]"
       )
 
       writeToFile(generator.attrDefsPackagePath, traitName, fileContent)
     }
 
-    // -- HTML props --
+    val propDefsList = defGroups.propDefGroups.flatMap(_._2)
 
     val htmlProps = {
       val traitName = "Props"
-      val traitNameWithParams = s"$traitName[F[_]]"
 
-      val fileContent = generator.generatePropsTrait(
-        defGroups = defGroups.propDefGroups.map {
-          case (key, vals) =>
-            (key, vals.map(attr => attr.copy(scalaValueType = "F, " + attr.scalaValueType)))
-        },
-        printDefGroupComments = true,
-        traitCommentLines = Nil,
-        traitModifiers = List("private"),
-        traitName = traitNameWithParams,
-        keyKind = "Prop",
-        implNameSuffix = "Prop",
-        baseImplDefComments = List(
-          "Create custom HTML element property",
-          "",
-          "@param key   - name of the prop in JS, e.g. \"value\"",
-          "@param codec - used to encode V into DomV, e.g. StringAsIsCodec,",
-          "",
-          "@tparam V    - value type for this prop in Scala",
-          "@tparam DomV - value type for this prop in the underlying JS DOM."
-        ),
-        baseImplName = "prop",
-        defType = LazyVal
+      val fileContent = generator.generatePhantomPropsTrait(
+        defGroups = defGroups.propDefGroups,
+        traitName = s"$traitName[F[_]]"
       )
 
       writeToFile(generator.propDefsPackagePath, traitName, fileContent)
     }
 
-    // -- Event props --
+    val validInstances = {
+      val traitName = "GeneratedValidInstances"
+
+      val fileContent = generator.generateValidInstances(
+        htmlAttrDefs = htmlAttrDefsList,
+        ariaAttrDefs = ariaAttrDefsList,
+        propDefs = propDefsList
+      )
+
+      writeToFile(generator.keysPackagePath, traitName, fileContent)
+    }
 
     val eventProps = {
       val baseTraitName = "GlobalEventProps"
@@ -332,71 +215,8 @@ object DomDefsGenerator {
       ).parFlatSequence
     }
 
-    // -- Style props --
-
-    // {
-    // val traitName = "StyleProps"
-
-    // val fileContent = generator.generateStylePropsTrait(
-    // defSources = defGroups.stylePropDefGroups,
-    // printDefGroupComments = true,
-    // traitCommentLines = Nil,
-    // traitName = traitName,
-    // keyKind = "StyleProp",
-    // keyKindAlias = "StyleProp",
-    // setterType = "StyleSetter",
-    // setterTypeAlias = "SS",
-    // derivedKeyKind = "DerivedStyleProp",
-    // derivedKeyKindAlias = "DSP",
-    // baseImplDefComments = List(
-    // "Create custom CSS property",
-    // "",
-    // "@param key - name of CSS property, e.g. \"font-weight\"",
-    // "",
-    // "@tparam V  - type of values recognized by JS for this property, e.g. Int",
-    // "             Note: String is always allowed regardless of the type you put here.",
-    // "             If unsure, use String type as V."
-    // ),
-    // baseImplName = "styleProp",
-    // defType = LazyVal,
-    // lengthUnitsNumType = "Int",
-    // outputUnitTraits = true
-    // )
-
-    // generator.writeToFile(
-    // packagePath = generator.stylePropDefsPackagePath,
-    // fileName = traitName,
-    // fileContent = fileContent
-    // )
-    // }
-
-    // -- Style keyword traits
-
-    // {
-    // StyleTraitDefs.defs.foreach { styleTrait =>
-    // val fileContent = generator.generateStyleKeywordsTrait(
-    // defSources = styleTrait.keywordDefGroups,
-    // printDefGroupComments = styleTrait.keywordDefGroups.length > 1,
-    // traitCommentLines = Nil,
-    // traitName = styleTrait.scalaName.replace("[_]", ""),
-    // extendsTraits = styleTrait.extendsTraits.map(_.replace("[_]", "")),
-    // extendsUnitTraits = styleTrait.extendsUnits,
-    // propKind = "StyleProp",
-    // keywordType = "StyleSetter",
-    // derivedKeyKind = "DerivedStyleProp",
-    // lengthUnitsNumType = "Int",
-    // defType = LazyVal,
-    // outputUnitTypes = true,
-    // allowSuperCallInOverride = false // can't access lazy val from `super`
-    // )
-
-    // generator.writeToFile(
-    // packagePath = generator.styleTraitsPackagePath(),
-    // fileName = styleTrait.scalaName.replace("[_]", ""),
-    // fileContent = fileContent
-    // )
-    // }
-    // }
-    List(List(htmlTags, htmlAttrs, ariaAttrs, htmlProps).sequence, eventProps).parFlatSequence
+    List(
+      List(htmlTags, htmlAttrs, ariaAttrs, htmlProps, validInstances).sequence,
+      eventProps).parFlatSequence
   }
 }

--- a/project/src/main/scala/calico/html/codegen/ElementScopes.scala
+++ b/project/src/main/scala/calico/html/codegen/ElementScopes.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.html.codegen
+
+/**
+ * Maps HTML attributes and properties to the element types they are valid on.
+ *
+ * fs2-dom provides specific types for:
+ *   - HtmlElement[F] (base for all HTML elements)
+ *   - HtmlAnchorElement[F]
+ *   - HtmlButtonElement[F]
+ *   - HtmlInputElement[F]
+ *   - HtmlOptionElement[F]
+ *   - HtmlSelectElement[F]
+ *   - HtmlTextAreaElement[F]
+ *
+ * Attributes not listed here are considered global (valid on all HtmlElement[F]).
+ */
+private[codegen] object ElementScopes {
+
+  /** fs2-dom element types that have specific subtypes */
+  val specificElementTypes: Set[String] = Set(
+    "HtmlAnchorElement",
+    "HtmlButtonElement",
+    "HtmlInputElement",
+    "HtmlOptionElement",
+    "HtmlSelectElement",
+    "HtmlTextAreaElement"
+  )
+
+  /**
+   * Maps an HTML attribute's Scala name to the set of specific element type names it applies to.
+   * Attributes NOT in this map are global (apply to all HtmlElement subtypes).
+   * Element types listed here correspond to fs2-dom types (without [F]).
+   *
+   * Note: only actual HTML attributes (from scala-dom-types AttrDef) belong here.
+   * DOM properties (from PropDef) belong in propScopes below.
+   */
+  val attrScopes: Map[String, Set[String]] = Map(
+    "href" -> Set("HtmlAnchorElement"),
+    "formId" -> Set("HtmlInputElement", "HtmlButtonElement", "HtmlSelectElement", "HtmlTextAreaElement"),
+    "maxAttr" -> Set("HtmlInputElement"),
+    "minAttr" -> Set("HtmlInputElement"),
+    "stepAttr" -> Set("HtmlInputElement")
+  )
+
+  /**
+   * Maps a property's Scala name to the set of specific element type names it applies to.
+   * Properties NOT in this map are global.
+   */
+  val propScopes: Map[String, Set[String]] = Map(
+    "checked" -> Set("HtmlInputElement"),
+    "indeterminate" -> Set("HtmlInputElement"),
+    "defaultChecked" -> Set("HtmlInputElement"),
+    "defaultValue" -> Set("HtmlInputElement", "HtmlTextAreaElement"),
+    "value" -> Set("HtmlInputElement", "HtmlTextAreaElement", "HtmlSelectElement", "HtmlOptionElement"),
+    "selected" -> Set("HtmlOptionElement"),
+    "multiple" -> Set("HtmlInputElement", "HtmlSelectElement"),
+    "disabled" -> Set("HtmlInputElement", "HtmlButtonElement", "HtmlSelectElement", "HtmlTextAreaElement", "HtmlOptionElement"),
+    "readOnly" -> Set("HtmlInputElement", "HtmlTextAreaElement")
+  )
+
+  /**
+   * Returns the fs2-dom element bound for a given attribute/property scope.
+   * If the attr/prop is global, returns "HtmlElement".
+   * If scoped to specific elements, returns each element type.
+   */
+  def elementBoundsForAttr(scalaName: String): List[String] =
+    attrScopes.get(scalaName) match {
+      case Some(elements) => elements.toList.sorted
+      case None => List("HtmlElement")
+    }
+
+  def elementBoundsForProp(scalaName: String): List[String] =
+    propScopes.get(scalaName) match {
+      case Some(elements) => elements.toList.sorted
+      case None => List("HtmlElement")
+    }
+}

--- a/project/src/main/scala/calico/html/codegen/ElementScopes.scala
+++ b/project/src/main/scala/calico/html/codegen/ElementScopes.scala
@@ -16,23 +16,8 @@
 
 package calico.html.codegen
 
-/**
- * Maps HTML attributes and properties to the element types they are valid on.
- *
- * fs2-dom provides specific types for:
- *   - HtmlElement[F] (base for all HTML elements)
- *   - HtmlAnchorElement[F]
- *   - HtmlButtonElement[F]
- *   - HtmlInputElement[F]
- *   - HtmlOptionElement[F]
- *   - HtmlSelectElement[F]
- *   - HtmlTextAreaElement[F]
- *
- * Attributes not listed here are considered global (valid on all HtmlElement[F]).
- */
 private[codegen] object ElementScopes {
 
-  /** fs2-dom element types that have specific subtypes */
   val specificElementTypes: Set[String] = Set(
     "HtmlAnchorElement",
     "HtmlButtonElement",
@@ -42,43 +27,39 @@ private[codegen] object ElementScopes {
     "HtmlTextAreaElement"
   )
 
-  /**
-   * Maps an HTML attribute's Scala name to the set of specific element type names it applies to.
-   * Attributes NOT in this map are global (apply to all HtmlElement subtypes).
-   * Element types listed here correspond to fs2-dom types (without [F]).
-   *
-   * Note: only actual HTML attributes (from scala-dom-types AttrDef) belong here.
-   * DOM properties (from PropDef) belong in propScopes below.
-   */
   val attrScopes: Map[String, Set[String]] = Map(
     "href" -> Set("HtmlAnchorElement"),
-    "formId" -> Set("HtmlInputElement", "HtmlButtonElement", "HtmlSelectElement", "HtmlTextAreaElement"),
+    "formId" -> Set(
+      "HtmlInputElement",
+      "HtmlButtonElement",
+      "HtmlSelectElement",
+      "HtmlTextAreaElement"),
     "maxAttr" -> Set("HtmlInputElement"),
     "minAttr" -> Set("HtmlInputElement"),
     "stepAttr" -> Set("HtmlInputElement")
   )
 
-  /**
-   * Maps a property's Scala name to the set of specific element type names it applies to.
-   * Properties NOT in this map are global.
-   */
   val propScopes: Map[String, Set[String]] = Map(
     "checked" -> Set("HtmlInputElement"),
     "indeterminate" -> Set("HtmlInputElement"),
     "defaultChecked" -> Set("HtmlInputElement"),
     "defaultValue" -> Set("HtmlInputElement", "HtmlTextAreaElement"),
-    "value" -> Set("HtmlInputElement", "HtmlTextAreaElement", "HtmlSelectElement", "HtmlOptionElement"),
+    "value" -> Set(
+      "HtmlInputElement",
+      "HtmlTextAreaElement",
+      "HtmlSelectElement",
+      "HtmlOptionElement"),
     "selected" -> Set("HtmlOptionElement"),
     "multiple" -> Set("HtmlInputElement", "HtmlSelectElement"),
-    "disabled" -> Set("HtmlInputElement", "HtmlButtonElement", "HtmlSelectElement", "HtmlTextAreaElement", "HtmlOptionElement"),
+    "disabled" -> Set(
+      "HtmlInputElement",
+      "HtmlButtonElement",
+      "HtmlSelectElement",
+      "HtmlTextAreaElement",
+      "HtmlOptionElement"),
     "readOnly" -> Set("HtmlInputElement", "HtmlTextAreaElement")
   )
 
-  /**
-   * Returns the fs2-dom element bound for a given attribute/property scope.
-   * If the attr/prop is global, returns "HtmlElement".
-   * If scoped to specific elements, returns each element type.
-   */
   def elementBoundsForAttr(scalaName: String): List[String] =
     attrScopes.get(scalaName) match {
       case Some(elements) => elements.toList.sorted


### PR DESCRIPTION
implements #180 

1. Added phantom type parameter A to HtmlAttr, AriaAttr, and Prop to identify each attribute at the type level
2. Added ValidAttr[A, E] and ValidProp[A, E] marker typeclasses (which are not variant in E) that gate which attributes can be used on which elements at compile time
3. Add ElementScopes mapping attributes to their valid element types.
4. Updated code generators to emit phantom-typed traits and ValidAttr/ValidProp given instances
5. Preserve source compatibility for aliases like typ and tpe still work
6. changed  tlBaseVersion  from 0.2 to 0.3 
used the context of issue 179 and 96
