### PR TITLE
Add wcProp factory for web component property binding

### DIFF
--- a/calico/src/main/scala/calico/html/Html.scala
+++ b/calico/src/main/scala/calico/html/Html.scala
@@ -65,3 +65,12 @@ sealed class Html[F[_]](using F: Async[F])
 
   def valueAttr: HtmlAttr[F, String] =
     HtmlAttr("value", encoders.identity)
+
+  /**
+   * JavaScript property by name (custom elements, Material, etc.).
+   */
+  def wcProp[V](name: String): Prop[F, V, V] =
+    new Prop(name, encoders.identity)
+
+  def wcProp[V, J](name: String, encode: V => J): Prop[F, V, J] =
+    new Prop(name, encode)


### PR DESCRIPTION
Web components expose their API through JS properties (el.value, el.disabled) 
not HTML attributes, so setAttribute doesn't work for them.

Calico already has Prop[F,V,J] with all the right machinery, but there was no 
public way to create one for an arbitrary property name outside of generated code.

This adds two methods to Html[F]:

  def wcProp[V](name: String): Prop[F, V, V]
  def wcProp[V, J](name: String, encode: V => J): Prop[F, V, J]

All existing Prop forms work automatically — :=, <--, Signal, Option variants.

Related to #37.